### PR TITLE
Added Token support to 2.0 (previously this was added for 1.1, but rathe...

### DIFF
--- a/src/Omnipay/SagePay/DirectGateway.php
+++ b/src/Omnipay/SagePay/DirectGateway.php
@@ -76,4 +76,23 @@ class DirectGateway extends AbstractGateway
     {
         return $this->createRequest('\Omnipay\SagePay\Message\RefundRequest', $parameters);
     }
+    
+    public function createCard(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\SagePay\Message\DirectCreateTokenRequest', $parameters);
+    }
+    
+    public function repeatPayment(array $parameters = array()){
+        return $this->createRequest('\Omnipay\SagePay\Message\DirectRepeatPaymentRequest', $parameters);
+    }
+
+    
+    public function deleteCard(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\SagePay\Message\DirectRemoveTokenRequest', $parameters);
+    }
+    
+    
+    
+    
 }

--- a/src/Omnipay/SagePay/DirectGateway.php
+++ b/src/Omnipay/SagePay/DirectGateway.php
@@ -82,7 +82,8 @@ class DirectGateway extends AbstractGateway
         return $this->createRequest('\Omnipay\SagePay\Message\DirectCreateTokenRequest', $parameters);
     }
     
-    public function repeatPayment(array $parameters = array()){
+    public function repeatPayment(array $parameters = array())
+    {
         return $this->createRequest('\Omnipay\SagePay\Message\DirectRepeatPaymentRequest', $parameters);
     }
 
@@ -91,8 +92,4 @@ class DirectGateway extends AbstractGateway
     {
         return $this->createRequest('\Omnipay\SagePay\Message\DirectRemoveTokenRequest', $parameters);
     }
-    
-    
-    
-    
 }

--- a/src/Omnipay/SagePay/Message/AbstractRequest.php
+++ b/src/Omnipay/SagePay/Message/AbstractRequest.php
@@ -21,6 +21,169 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return $this->setParameter('vendor', $value);
     }
 
+    public function getFirstName(){
+        return $this->getParameter('firstName');
+    }
+    
+    public function setFirstName($value)
+    {
+        return $this->setParameter('firstName', $value);
+    }
+    
+    public function getLastName(){
+        return $this->getParameter('lastName');
+    }
+    
+    public function setLastName($value)
+    {
+        return $this->setParameter('lastName', $value);
+    }
+    
+    
+    public function getBillingAddress1(){
+        return $this->getParameter('billingAddress1');
+    }
+    
+    public function setBillingAddress1($value)
+    {
+        return $this->setParameter('billingAddress1', $value);
+    }
+    
+    public function getBillingAddress2(){
+        return $this->getParameter('billingAddress2');
+    }
+    
+    public function setBillingAddress2($value)
+    {
+        return $this->setParameter('billingAddress2', $value);
+    }
+    
+    public function getBillingCity(){
+        return $this->getParameter('billingCity');
+    }
+    
+    public function setBillingCity($value)
+    {
+        return $this->setParameter('billingCity', $value);
+    }
+    
+    public function getBillingPostcode(){
+        return $this->getParameter('billingPostcode');
+    }
+    
+    public function setBillingPostcode($value)
+    {
+        return $this->setParameter('billingPostcode', $value);
+    }
+    
+    public function getBillingState(){
+        return $this->getParameter('billingState');
+    }
+    
+    public function setBillingState($value)
+    {
+        return $this->setParameter('billingState', $value);
+    }
+    
+    public function getBillingPhone(){
+        return $this->getParameter('billingPhone');
+    }
+    
+    public function setBillingPhone($value)
+    {
+        return $this->setParameter('billingPhone', $value);
+    }
+    
+    public function getBillingCountry(){
+        return $this->getParameter('billingCountry');
+    }
+    
+    public function setBillingCountry($value)
+    {
+        return $this->setParameter('billingCountry', $value);
+    }
+    
+    public function getShippingAddress1(){
+        return $this->getParameter('shippingAddress1');
+    }
+    
+    public function setShippingAddress1($value)
+    {
+        return $this->setParameter('shippingAddress1', $value);
+    }
+    
+    public function getShippingAddress2(){
+        return $this->getParameter('shippingAddress2');
+    }
+    
+    public function setShippingAddress2($value)
+    {
+        return $this->setParameter('shippingAddress2', $value);
+    }
+    
+    public function getShippingCity(){
+        return $this->getParameter('shippingCity');
+    }
+    
+    public function setShippingCity($value)
+    {
+        return $this->setParameter('shippingCity', $value);
+    }
+    
+    public function getShippingPostcode(){
+        return $this->getParameter('shippingPostcode');
+    }
+    
+    public function setShippingPostcode($value)
+    {
+        return $this->setParameter('shippingPostcode', $value);
+    }
+    
+    public function getShippingState(){
+        return $this->getParameter('shippingState');
+    }
+    
+    public function setShippingState($value)
+    {
+        return $this->setParameter('shippingState', $value);
+    }
+    
+    public function getShippingPhone(){
+        return $this->getParameter('shippingPhone');
+    }
+    
+    public function setShippingPhone($value)
+    {
+        return $this->setParameter('shippingPhone', $value);
+    }
+    
+    public function getShippingCountry(){
+        return $this->getParameter('shippingCountry');
+    }
+    
+    public function setShippingCountry($value)
+    {
+        return $this->setParameter('shippingCountry', $value);
+    }
+     
+    public function getCompany(){
+        return $this->getParameter('company');
+    }
+    
+    public function setCompany($value)
+    {
+        return $this->setParameter('company', $value);
+    }
+    
+     public function getEmail(){
+        return $this->getParameter('email');
+    }
+    
+    public function setEmail($value)
+    {
+        return $this->setParameter('email', $value);
+    }
+    
     public function getSimulatorMode()
     {
         return $this->getParameter('simulatorMode');

--- a/src/Omnipay/SagePay/Message/AbstractRequest.php
+++ b/src/Omnipay/SagePay/Message/AbstractRequest.php
@@ -21,7 +21,8 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return $this->setParameter('vendor', $value);
     }
 
-    public function getFirstName(){
+    public function getFirstName()
+    {
         return $this->getParameter('firstName');
     }
     
@@ -30,7 +31,8 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return $this->setParameter('firstName', $value);
     }
     
-    public function getLastName(){
+    public function getLastName()
+    {
         return $this->getParameter('lastName');
     }
     
@@ -40,7 +42,8 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     }
     
     
-    public function getBillingAddress1(){
+    public function getBillingAddress1()
+    {
         return $this->getParameter('billingAddress1');
     }
     
@@ -49,7 +52,8 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return $this->setParameter('billingAddress1', $value);
     }
     
-    public function getBillingAddress2(){
+    public function getBillingAddress2()
+    {
         return $this->getParameter('billingAddress2');
     }
     
@@ -58,7 +62,8 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return $this->setParameter('billingAddress2', $value);
     }
     
-    public function getBillingCity(){
+    public function getBillingCity()
+    {
         return $this->getParameter('billingCity');
     }
     
@@ -67,7 +72,8 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return $this->setParameter('billingCity', $value);
     }
     
-    public function getBillingPostcode(){
+    public function getBillingPostcode()
+    {
         return $this->getParameter('billingPostcode');
     }
     
@@ -76,7 +82,8 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return $this->setParameter('billingPostcode', $value);
     }
     
-    public function getBillingState(){
+    public function getBillingState()
+    {
         return $this->getParameter('billingState');
     }
     
@@ -85,7 +92,8 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return $this->setParameter('billingState', $value);
     }
     
-    public function getBillingPhone(){
+    public function getBillingPhone()
+    {
         return $this->getParameter('billingPhone');
     }
     
@@ -94,7 +102,8 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return $this->setParameter('billingPhone', $value);
     }
     
-    public function getBillingCountry(){
+    public function getBillingCountry()
+    {
         return $this->getParameter('billingCountry');
     }
     
@@ -103,7 +112,8 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return $this->setParameter('billingCountry', $value);
     }
     
-    public function getShippingAddress1(){
+    public function getShippingAddress1()
+    {
         return $this->getParameter('shippingAddress1');
     }
     
@@ -112,7 +122,8 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return $this->setParameter('shippingAddress1', $value);
     }
     
-    public function getShippingAddress2(){
+    public function getShippingAddress2()
+    {
         return $this->getParameter('shippingAddress2');
     }
     
@@ -121,7 +132,8 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return $this->setParameter('shippingAddress2', $value);
     }
     
-    public function getShippingCity(){
+    public function getShippingCity()
+    {
         return $this->getParameter('shippingCity');
     }
     
@@ -130,7 +142,8 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return $this->setParameter('shippingCity', $value);
     }
     
-    public function getShippingPostcode(){
+    public function getShippingPostcode()
+    {
         return $this->getParameter('shippingPostcode');
     }
     
@@ -139,7 +152,8 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return $this->setParameter('shippingPostcode', $value);
     }
     
-    public function getShippingState(){
+    public function getShippingState()
+    {
         return $this->getParameter('shippingState');
     }
     
@@ -148,7 +162,8 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return $this->setParameter('shippingState', $value);
     }
     
-    public function getShippingPhone(){
+    public function getShippingPhone()
+    {
         return $this->getParameter('shippingPhone');
     }
     
@@ -157,7 +172,8 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return $this->setParameter('shippingPhone', $value);
     }
     
-    public function getShippingCountry(){
+    public function getShippingCountry()
+    {
         return $this->getParameter('shippingCountry');
     }
     
@@ -166,7 +182,8 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return $this->setParameter('shippingCountry', $value);
     }
      
-    public function getCompany(){
+    public function getCompany()
+    {
         return $this->getParameter('company');
     }
     
@@ -175,7 +192,8 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return $this->setParameter('company', $value);
     }
     
-     public function getEmail(){
+    public function getEmail()
+    {
         return $this->getParameter('email');
     }
     

--- a/src/Omnipay/SagePay/Message/DirectAuthorizeRequest.php
+++ b/src/Omnipay/SagePay/Message/DirectAuthorizeRequest.php
@@ -27,29 +27,29 @@ class DirectAuthorizeRequest extends AbstractRequest
 
         if(!$this->getCardReference()){
             $card = $this->getCard();
-        // billing details
-        $data['BillingFirstnames'] = $card->getFirstName();
-        $data['BillingSurname'] = $card->getLastName();
-        $data['BillingAddress1'] = $card->getBillingAddress1();
-        $data['BillingAddress2'] = $card->getBillingAddress2();
-        $data['BillingCity'] = $card->getBillingCity();
-        $data['BillingPostCode'] = $card->getBillingPostcode();
-        $data['BillingState'] = $card->getBillingCountry() === 'US' ? $card->getBillingState() : null;
-        $data['BillingCountry'] = $card->getBillingCountry();
-        $data['BillingPhone'] = $card->getBillingPhone();
+            // billing details
+            $data['BillingFirstnames'] = $card->getFirstName();
+            $data['BillingSurname'] = $card->getLastName();
+            $data['BillingAddress1'] = $card->getBillingAddress1();
+            $data['BillingAddress2'] = $card->getBillingAddress2();
+            $data['BillingCity'] = $card->getBillingCity();
+            $data['BillingPostCode'] = $card->getBillingPostcode();
+            $data['BillingState'] = $card->getBillingCountry() === 'US' ? $card->getBillingState() : null;
+            $data['BillingCountry'] = $card->getBillingCountry();
+            $data['BillingPhone'] = $card->getBillingPhone();
 
-        // shipping details
-        $data['DeliveryFirstnames'] = $card->getFirstName();
-        $data['DeliverySurname'] = $card->getLastName();
-        $data['DeliveryAddress1'] = $card->getShippingAddress1();
-        $data['DeliveryAddress2'] = $card->getShippingAddress2();
-        $data['DeliveryCity'] = $card->getShippingCity();
-        $data['DeliveryPostCode'] = $card->getShippingPostcode();
-        $data['DeliveryState'] = $card->getShippingCountry() === 'US' ? $card->getShippingState() : null;
-        $data['DeliveryCountry'] = $card->getShippingCountry();
-        $data['DeliveryPhone'] = $card->getShippingPhone();
-        $data['CustomerEMail'] = $card->getEmail();
-        }else{
+            // shipping details
+            $data['DeliveryFirstnames'] = $card->getFirstName();
+            $data['DeliverySurname'] = $card->getLastName();
+            $data['DeliveryAddress1'] = $card->getShippingAddress1();
+            $data['DeliveryAddress2'] = $card->getShippingAddress2();
+            $data['DeliveryCity'] = $card->getShippingCity();
+            $data['DeliveryPostCode'] = $card->getShippingPostcode();
+            $data['DeliveryState'] = $card->getShippingCountry() === 'US' ? $card->getShippingState() : null;
+            $data['DeliveryCountry'] = $card->getShippingCountry();
+            $data['DeliveryPhone'] = $card->getShippingPhone();
+            $data['CustomerEMail'] = $card->getEmail();
+        } else {
             //Card hasnt been sent so Values need to come from parameteres
             $data['BillingFirstnames'] = $this->getFirstName();
             $data['BillingSurname'] = $this->getLastName();
@@ -82,27 +82,27 @@ class DirectAuthorizeRequest extends AbstractRequest
         $data = $this->getBaseAuthorizeData();
         
         //If this is a Token payment, add the Token data item, otherwise its a normal card purchase.
-        if($this->getCardReference()){
+        if ($this->getCardReference()){
             $data['Token']      = $this->getCardReference();
             $data['CV2']        =   $this->getParameter('cvv');
             $data['StoreToken'] = 1;
             
-        }else{
-        $this->getCard()->validate();
+        } else {
+            $this->getCard()->validate();
 
-        $data['CardHolder'] = $this->getCard()->getName();
-        $data['CardNumber'] = $this->getCard()->getNumber();
-        $data['ExpiryDate'] = $this->getCard()->getExpiryDate('my');
-        $data['CV2'] = $this->getCard()->getCvv();
-        $data['CardType'] = $this->getCardBrand();
+            $data['CardHolder'] = $this->getCard()->getName();
+            $data['CardNumber'] = $this->getCard()->getNumber();
+            $data['ExpiryDate'] = $this->getCard()->getExpiryDate('my');
+            $data['CV2'] = $this->getCard()->getCvv();
+            $data['CardType'] = $this->getCardBrand();
 
-        if ($this->getCard()->getStartMonth() and $this->getCard()->getStartYear()) {
-            $data['StartDate'] = $this->getCard()->getStartDate('my');
-        }
+            if ($this->getCard()->getStartMonth() and $this->getCard()->getStartYear()) {
+                $data['StartDate'] = $this->getCard()->getStartDate('my');
+            }
 
-        if ($this->getCard()->getIssueNumber()) {
-            $data['IssueNumber'] = $this->getCard()->getIssueNumber();
-        }
+            if ($this->getCard()->getIssueNumber()) {
+                $data['IssueNumber'] = $this->getCard()->getIssueNumber();
+            }
 
         }
 

--- a/src/Omnipay/SagePay/Message/DirectAuthorizeRequest.php
+++ b/src/Omnipay/SagePay/Message/DirectAuthorizeRequest.php
@@ -25,7 +25,8 @@ class DirectAuthorizeRequest extends AbstractRequest
         $data['ApplyAVSCV2'] = 0; // use account setting
         $data['Apply3DSecure'] = 0; // use account setting
 
-        if(!$this->getCardReference()){
+        if(!$this->getCardReference())
+        {
             $card = $this->getCard();
             // billing details
             $data['BillingFirstnames'] = $card->getFirstName();
@@ -82,7 +83,7 @@ class DirectAuthorizeRequest extends AbstractRequest
         $data = $this->getBaseAuthorizeData();
         
         //If this is a Token payment, add the Token data item, otherwise its a normal card purchase.
-        if ($this->getCardReference()){
+        if ($this->getCardReference()) {
             $data['Token']      = $this->getCardReference();
             $data['CV2']        =   $this->getParameter('cvv');
             $data['StoreToken'] = 1;

--- a/src/Omnipay/SagePay/Message/DirectAuthorizeRequest.php
+++ b/src/Omnipay/SagePay/Message/DirectAuthorizeRequest.php
@@ -25,8 +25,7 @@ class DirectAuthorizeRequest extends AbstractRequest
         $data['ApplyAVSCV2'] = 0; // use account setting
         $data['Apply3DSecure'] = 0; // use account setting
 
-        if(!$this->getCardReference())
-        {
+        if(!$this->getCardReference()) {
             $card = $this->getCard();
             // billing details
             $data['BillingFirstnames'] = $card->getFirstName();

--- a/src/Omnipay/SagePay/Message/DirectAuthorizeRequest.php
+++ b/src/Omnipay/SagePay/Message/DirectAuthorizeRequest.php
@@ -15,9 +15,7 @@ class DirectAuthorizeRequest extends AbstractRequest
 
     protected function getBaseAuthorizeData()
     {
-        $this->validate('amount', 'card', 'transactionId');
-        $card = $this->getCard();
-
+        $this->validate('amount', 'transactionId');
         $data = $this->getBaseData();
         $data['Description'] = $this->getDescription();
         $data['Amount'] = $this->getAmount();
@@ -27,6 +25,8 @@ class DirectAuthorizeRequest extends AbstractRequest
         $data['ApplyAVSCV2'] = 0; // use account setting
         $data['Apply3DSecure'] = 0; // use account setting
 
+        if(!$this->getCardReference()){
+            $card = $this->getCard();
         // billing details
         $data['BillingFirstnames'] = $card->getFirstName();
         $data['BillingSurname'] = $card->getLastName();
@@ -49,19 +49,51 @@ class DirectAuthorizeRequest extends AbstractRequest
         $data['DeliveryCountry'] = $card->getShippingCountry();
         $data['DeliveryPhone'] = $card->getShippingPhone();
         $data['CustomerEMail'] = $card->getEmail();
+        }else{
+            //Card hasnt been sent so Values need to come from parameteres
+            $data['BillingFirstnames'] = $this->getFirstName();
+            $data['BillingSurname'] = $this->getLastName();
+            $data['BillingAddress1'] = $this->getBillingAddress1();
+            $data['BillingAddress2'] = $this->getBillingAddress2();
+            $data['BillingCity'] = $this->getBillingCity();
+            $data['BillingPostCode'] = $this->getBillingPostcode();
+            $data['BillingState'] = $this->getBillingCountry() === 'US' ? $this->getBillingState() : null;
+            $data['BillingCountry'] = $this->getBillingCountry();
+            $data['BillingPhone'] = $this->getBillingPhone();
 
+            // shipping details
+            $data['DeliveryFirstnames'] = $this->getFirstName();
+            $data['DeliverySurname'] = $this->getLastName();
+            $data['DeliveryAddress1'] = $this->getShippingAddress1();
+            $data['DeliveryAddress2'] = $this->getShippingAddress2();
+            $data['DeliveryCity'] = $this->getShippingCity();
+            $data['DeliveryPostCode'] = $this->getShippingPostcode();
+            $data['DeliveryState'] = $this->getShippingCountry() === 'US' ? $this->getShippingState() : null;
+            $data['DeliveryCountry'] = $this->getShippingCountry();
+            $data['DeliveryPhone'] = $this->getShippingPhone();
+            $data['CustomerEMail'] = $this->getEmail();
+            
+        }
         return $data;
     }
 
     public function getData()
     {
         $data = $this->getBaseAuthorizeData();
+        
+        //If this is a Token payment, add the Token data item, otherwise its a normal card purchase.
+        if($this->getCardReference()){
+            $data['Token']      = $this->getCardReference();
+            $data['CV2']        =   $this->getParameter('cvv');
+            $data['StoreToken'] = 1;
+            
+        }else{
         $this->getCard()->validate();
 
         $data['CardHolder'] = $this->getCard()->getName();
         $data['CardNumber'] = $this->getCard()->getNumber();
-        $data['CV2'] = $this->getCard()->getCvv();
         $data['ExpiryDate'] = $this->getCard()->getExpiryDate('my');
+        $data['CV2'] = $this->getCard()->getCvv();
         $data['CardType'] = $this->getCardBrand();
 
         if ($this->getCard()->getStartMonth() and $this->getCard()->getStartYear()) {
@@ -71,6 +103,11 @@ class DirectAuthorizeRequest extends AbstractRequest
         if ($this->getCard()->getIssueNumber()) {
             $data['IssueNumber'] = $this->getCard()->getIssueNumber();
         }
+
+        }
+
+        
+        
 
         return $data;
     }

--- a/src/Omnipay/SagePay/Message/DirectAuthorizeRequest.php
+++ b/src/Omnipay/SagePay/Message/DirectAuthorizeRequest.php
@@ -25,7 +25,7 @@ class DirectAuthorizeRequest extends AbstractRequest
         $data['ApplyAVSCV2'] = 0; // use account setting
         $data['Apply3DSecure'] = 0; // use account setting
 
-        if(!$this->getCardReference()) {
+        if (!$this->getCardReference()) {
             $card = $this->getCard();
             // billing details
             $data['BillingFirstnames'] = $card->getFirstName();

--- a/src/Omnipay/SagePay/Message/DirectCreateTokenRequest.php
+++ b/src/Omnipay/SagePay/Message/DirectCreateTokenRequest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Omnipay\SagePay\Message;
+
+
+/**
+ * Sage Pay Direct Create Token Request
+ */
+class DirectCreateTokenRequest extends AbstractRequest
+
+{
+    protected $action = 'TOKEN';
+    protected $cardBrandMap = array(
+        'mastercard' => 'mc',
+        'diners_club' => 'dc'
+    );
+
+    protected function getBaseAuthorizeData()
+    {
+        $data = $this->getBaseData();
+        
+        //$data['Currency'] = $this->getParameter['Currency'];
+        
+        $data['ClientIPAddress'] = $this->getClientIp();
+        $data['ApplyAVSCV2'] = 0; // use account setting
+        $data['Apply3DSecure'] = 0; // use account setting
+        
+        $data['StoreToken'] = 1; //Token needs to be kept
+
+       
+
+        return $data;
+        
+    }
+
+    public function getData()
+    {
+        $data = $this->getBaseAuthorizeData();
+        $card = $this->getCard();
+
+        $data['Currency'] = 'GBP';
+        $data['CardNumber'] = $card->getNumber();
+        $data['ExpiryDate'] = $card->getExpiryDate('my');
+        $data['CardType']   = $this->getCardBrand();
+        $data['CardHolder'] = $card->getName();
+        
+        // billing details
+        $data['BillingFirstnames'] = $card->getFirstName();
+        $data['BillingSurname'] = $card->getLastName();
+        $data['BillingAddress1'] = $card->getBillingAddress1();
+        $data['BillingAddress2'] = $card->getBillingAddress2();
+        $data['BillingCity'] = $card->getBillingCity();
+        $data['BillingPostCode'] = $card->getBillingPostcode();
+        $data['BillingState'] = $card->getBillingCountry() === 'US' ? $card->getBillingState() : null;
+        $data['BillingCountry'] = $card->getBillingCountry();
+        $data['BillingPhone'] = $card->getBillingPhone();
+
+        // shipping details
+        $data['DeliveryFirstnames'] = $card->getFirstName();
+        $data['DeliverySurname'] = $card->getLastName();
+        $data['DeliveryAddress1'] = $card->getShippingAddress1();
+        $data['DeliveryAddress2'] = $card->getShippingAddress2();
+        $data['DeliveryCity'] = $card->getShippingCity();
+        $data['DeliveryPostCode'] = $card->getShippingPostcode();
+        $data['DeliveryState'] = $card->getShippingCountry() === 'US' ? $card->getShippingState() : null;
+        $data['DeliveryCountry'] = $card->getShippingCountry();
+        $data['DeliveryPhone'] = $card->getShippingPhone();
+        $data['CustomerEMail'] = $card->getEmail();
+        
+        
+        if ($card->getStartMonth() && $card->getStartYear()) {
+            $data['StartDate'] = $card->getStartDate('my');
+        }
+        if ($card->getIssueNumber()) {
+            $data['IssueNumber'] = $card->getIssueNumber();
+        }
+        $data['CV2'] = $card->getCvv();
+
+
+        return $data;
+    }
+
+    public function getService()
+    {
+        return 'directtoken';
+    }
+
+    protected function getCardBrand()
+    {
+        $brand = $this->getCard()->getBrand();
+
+        if (isset($this->cardBrandMap[$brand])) {
+            return $this->cardBrandMap[$brand];
+        }
+
+        return $brand;
+    }
+}

--- a/src/Omnipay/SagePay/Message/DirectCreateTokenRequest.php
+++ b/src/Omnipay/SagePay/Message/DirectCreateTokenRequest.php
@@ -7,7 +7,6 @@ namespace Omnipay\SagePay\Message;
  * Sage Pay Direct Create Token Request
  */
 class DirectCreateTokenRequest extends AbstractRequest
-
 {
     protected $action = 'TOKEN';
     protected $cardBrandMap = array(

--- a/src/Omnipay/SagePay/Message/DirectRemoveTokenRequest.php
+++ b/src/Omnipay/SagePay/Message/DirectRemoveTokenRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Omnipay\SagePay\Message;
+
+/**
+ * Sage Pay Direct Remove Token Request
+ */
+class DirectRemoveTokenRequest extends AbstractRequest
+{
+    protected $action = 'REMOVETOKEN';
+    
+    protected function getBaseAuthorizeData()
+    {
+        $data = $this->getBaseData();
+
+        return $data;
+    }    
+    
+    public function getData()
+    {
+        $data = $this->getBaseAuthorizeData();
+        //Add the token ID to remove
+        $data['Token'] = $this->getParameter('cardReference');
+
+        return $data;
+    }
+    
+    public function getService()
+    {
+        return 'removetoken';
+    }
+}

--- a/src/Omnipay/SagePay/Message/DirectRemoveTokenRequest.php
+++ b/src/Omnipay/SagePay/Message/DirectRemoveTokenRequest.php
@@ -14,8 +14,8 @@ class DirectRemoveTokenRequest extends AbstractRequest
         $data = $this->getBaseData();
 
         return $data;
-    }    
-    
+    }
+
     public function getData()
     {
         $data = $this->getBaseAuthorizeData();

--- a/src/Omnipay/SagePay/Message/DirectRepeatPaymentRequest.php
+++ b/src/Omnipay/SagePay/Message/DirectRepeatPaymentRequest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Omnipay\SagePay\Message;
+
+/**
+ * Sage Pay Direct Purchase Request
+ */
+class DirectRepeatPaymentRequest extends AbstractRequest
+
+{
+    protected $action = 'REPEAT';
+    
+    protected function getBaseAuthorizeData()
+    {
+        $data = $this->getBaseData();
+        
+        return $data;
+        
+    }
+
+    public function getData()
+    {
+        $data = $this->getBaseAuthorizeData();
+        
+
+        $data['Currency'] = 'GBP';
+        $data['Amount'] = $this->getAmount();
+        
+        $data['Description'] = $this->getDescription();
+        //Unique reference to THIS payment
+        $data['VendorTxCode'] = $this->getTransactionId();
+        
+        //Specific to repeat payments
+        //Return results from previous Payments
+        $data['RelatedVPSTxId'] = $this->getRelatedVPSTxId();
+        $data['RelatedVendorTxCode'] = $this->getRelatedTransactionId();
+        $data['RelatedSecurityKey'] = $this->getRelatedSecurityKey();
+        $data['RelatedTxAuthNo'] = $this->getRelatedTxAuthNo();
+        
+        // billing details
+        return $data;
+    }
+    
+  
+    public function getDescription(){
+        return $this->getParameter('description');
+    }
+    
+    public function setDescription($value)
+    {
+        return $this->setParameter('description', $value);
+    }
+  
+    public function getRelatedVPSTxId(){
+        return $this->getParameter('relatedVPSTxId');
+    }
+    
+    public function setRelatedVPSTxId($value)
+    {
+        return $this->setParameter('relatedVPSTxId', $value);
+    }
+    
+    public function getRelatedTransactionId(){
+        return $this->getParameter('relatedTransactionId');
+    }
+    
+    public function setRelatedTransactionId($value)
+    {
+        return $this->setParameter('relatedTransactionId', $value);
+    }
+   
+    public function getRelatedSecurityKey(){
+        return $this->getParameter('relatedSecurityKey');
+    }
+    
+    public function setRelatedSecurityKey($value)
+    {
+        return $this->setParameter('relatedSecurityKey', $value);
+    }
+   
+    public function getRelatedTxAuthNo(){
+        return $this->getParameter('relatedTxAuthNo');
+    }
+    
+    public function setRelatedTxAuthNo($value)
+    {
+        return $this->setParameter('relatedTxAuthNo', $value);
+    }
+    
+    
+    public function getService()
+    {
+        return 'repeat';
+    }
+
+  } 

--- a/src/Omnipay/SagePay/Message/DirectRepeatPaymentRequest.php
+++ b/src/Omnipay/SagePay/Message/DirectRepeatPaymentRequest.php
@@ -96,6 +96,3 @@ class DirectRepeatPaymentRequest extends AbstractRequest
         return 'repeat';
     }
 }
-
-
- 

--- a/src/Omnipay/SagePay/Message/DirectRepeatPaymentRequest.php
+++ b/src/Omnipay/SagePay/Message/DirectRepeatPaymentRequest.php
@@ -6,7 +6,6 @@ namespace Omnipay\SagePay\Message;
  * Sage Pay Direct Purchase Request
  */
 class DirectRepeatPaymentRequest extends AbstractRequest
-
 {
     protected $action = 'REPEAT';
     
@@ -42,7 +41,8 @@ class DirectRepeatPaymentRequest extends AbstractRequest
     }
     
   
-    public function getDescription(){
+    public function getDescription()
+    {
         return $this->getParameter('description');
     }
     
@@ -51,7 +51,8 @@ class DirectRepeatPaymentRequest extends AbstractRequest
         return $this->setParameter('description', $value);
     }
   
-    public function getRelatedVPSTxId(){
+    public function getRelatedVPSTxId()
+    {
         return $this->getParameter('relatedVPSTxId');
     }
     
@@ -60,7 +61,8 @@ class DirectRepeatPaymentRequest extends AbstractRequest
         return $this->setParameter('relatedVPSTxId', $value);
     }
     
-    public function getRelatedTransactionId(){
+    public function getRelatedTransactionId()
+    {
         return $this->getParameter('relatedTransactionId');
     }
     
@@ -69,7 +71,8 @@ class DirectRepeatPaymentRequest extends AbstractRequest
         return $this->setParameter('relatedTransactionId', $value);
     }
    
-    public function getRelatedSecurityKey(){
+    public function getRelatedSecurityKey()
+    {
         return $this->getParameter('relatedSecurityKey');
     }
     
@@ -78,7 +81,8 @@ class DirectRepeatPaymentRequest extends AbstractRequest
         return $this->setParameter('relatedSecurityKey', $value);
     }
    
-    public function getRelatedTxAuthNo(){
+    public function getRelatedTxAuthNo()
+    {
         return $this->getParameter('relatedTxAuthNo');
     }
     
@@ -87,10 +91,9 @@ class DirectRepeatPaymentRequest extends AbstractRequest
         return $this->setParameter('relatedTxAuthNo', $value);
     }
     
-    
     public function getService()
     {
         return 'repeat';
     }
-
   } 
+  

--- a/src/Omnipay/SagePay/Message/DirectRepeatPaymentRequest.php
+++ b/src/Omnipay/SagePay/Message/DirectRepeatPaymentRequest.php
@@ -95,5 +95,7 @@ class DirectRepeatPaymentRequest extends AbstractRequest
     {
         return 'repeat';
     }
-  } 
-  
+}
+
+
+ 

--- a/src/Omnipay/SagePay/Message/Response.php
+++ b/src/Omnipay/SagePay/Message/Response.php
@@ -57,6 +57,10 @@ class Response extends AbstractResponse implements RedirectResponseInterface
         return isset($this->data['StatusDetail']) ? $this->data['StatusDetail'] : null;
     }
 
+	public function getToken(){
+		return isset($this->data['Token']) ? $this->data['Token'] : null;
+	}
+
     public function getRedirectUrl()
     {
         if ($this->isRedirect()) {

--- a/src/Omnipay/SagePay/Message/Response.php
+++ b/src/Omnipay/SagePay/Message/Response.php
@@ -57,9 +57,10 @@ class Response extends AbstractResponse implements RedirectResponseInterface
         return isset($this->data['StatusDetail']) ? $this->data['StatusDetail'] : null;
     }
 
-	public function getToken(){
-		return isset($this->data['Token']) ? $this->data['Token'] : null;
-	}
+    public function getToken()
+    {
+        return isset($this->data['Token']) ? $this->data['Token'] : null;
+    }
 
     public function getRedirectUrl()
     {


### PR DESCRIPTION
Added in Token support for SagePay here. Adding and Removing a token are supported, updates are not support by Sage.

Repeat payments are also added here in DirectRepeatPaymentRequest, these allow you to use a previous transactions return codes to request another payment (without having to pass any card details or personal information, or to have to use a token, as not all accounts have Token support enabled by default)