### PR TITLE
Pass through empty state if the country is not US

### DIFF
--- a/src/Message/DirectAuthorizeRequest.php
+++ b/src/Message/DirectAuthorizeRequest.php
@@ -34,7 +34,7 @@ class DirectAuthorizeRequest extends AbstractRequest
         $data['BillingAddress2'] = $card->getBillingAddress2();
         $data['BillingCity'] = $card->getBillingCity();
         $data['BillingPostCode'] = $card->getBillingPostcode();
-        $data['BillingState'] = $card->getBillingCountry() === 'US' ? $card->getBillingState() : null;
+        $data['BillingState'] = $card->getBillingCountry() === 'US' ? $card->getBillingState() : '';
         $data['BillingCountry'] = $card->getBillingCountry();
         $data['BillingPhone'] = $card->getBillingPhone();
 
@@ -45,7 +45,7 @@ class DirectAuthorizeRequest extends AbstractRequest
         $data['DeliveryAddress2'] = $card->getShippingAddress2();
         $data['DeliveryCity'] = $card->getShippingCity();
         $data['DeliveryPostCode'] = $card->getShippingPostcode();
-        $data['DeliveryState'] = $card->getShippingCountry() === 'US' ? $card->getShippingState() : null;
+        $data['DeliveryState'] = $card->getShippingCountry() === 'US' ? $card->getShippingState() : '';
         $data['DeliveryCountry'] = $card->getShippingCountry();
         $data['DeliveryPhone'] = $card->getShippingPhone();
         $data['CustomerEMail'] = $card->getEmail();


### PR DESCRIPTION
Although the documentation for Sagepay Direct says that the State is optional it is failing unless an empty state is passed through for non US countries. This appears to also be the case for Sagepay Server.
