### PR TITLE
Allow "OK REPEATED" status responses for redirects

### DIFF
--- a/src/Message/ServerAuthorizeResponse.php
+++ b/src/Message/ServerAuthorizeResponse.php
@@ -14,7 +14,10 @@ class ServerAuthorizeResponse extends Response
 
     public function isRedirect()
     {
-        return isset($this->data['Status']) && 'OK' === $this->data['Status'];
+        return isset($this->data['Status']) && (
+            'OK' === $this->data['Status'] ||
+            'OK REPEATED' === $this->data['Status']
+        );
     }
 
     public function getRedirectUrl()


### PR DESCRIPTION
If a customer times-out or closes their SagePay tab then when they try later SagePay responds with `OK REPEATED`. This is still a valid payment and as far as I can determine this should be allowed to continue. These responses have a `NextUrl` value so can be redirected.

This pull request simply accepts `OK REPEATED` as a valid redirect-able response status.
