### PR TITLE
Referrerid

### DIFF
--- a/src/DirectGateway.php
+++ b/src/DirectGateway.php
@@ -24,6 +24,7 @@ class DirectGateway extends AbstractGateway
             'vendor' => '',
             'testMode' => false,
             'simulatorMode' => false,
+            'referrerId' => '',
         );
     }
 
@@ -45,6 +46,16 @@ class DirectGateway extends AbstractGateway
     public function setSimulatorMode($value)
     {
         return $this->setParameter('simulatorMode', $value);
+    }
+
+    public function getReferrerId()
+    {
+        return $this->getParameter('referrerId');
+    }
+
+    public function setReferrerId($value)
+    {
+        return $this->setParameter('referrerId', $value);
     }
 
     public function authorize(array $parameters = array())

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -55,6 +55,19 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return $this->setParameter('accountType', $value);
     }
 
+    public function getReferrerId()
+    {
+        return $this->getParameter('referrerId');
+    }
+
+    /**
+     * Set the referrer ID for PAYMENT, DEFERRED and AUTHENTICATE transactions.
+     */
+    public function setReferrerId($value)
+    {
+        return $this->setParameter('referrerId', $value);
+    }
+
     public function getApplyAVSCV2()
     {
         return $this->getParameter('applyAVSCV2');

--- a/src/Message/DirectAuthorizeRequest.php
+++ b/src/Message/DirectAuthorizeRequest.php
@@ -26,7 +26,10 @@ class DirectAuthorizeRequest extends AbstractRequest
         $data['ClientIPAddress'] = $this->getClientIp();
         $data['ApplyAVSCV2'] = $this->getApplyAVSCV2() ?: 0;
         $data['Apply3DSecure'] = $this->getApply3DSecure() ?: 0;
-        $data['ReferrerID'] = $this->getReferrerId();
+
+        if ($this->getReferrerId()) {
+            $data['ReferrerID'] = $this->getReferrerId();
+        }
 
         // billing details
         $data['BillingFirstnames'] = $card->getBillingFirstName();

--- a/src/Message/DirectAuthorizeRequest.php
+++ b/src/Message/DirectAuthorizeRequest.php
@@ -26,6 +26,7 @@ class DirectAuthorizeRequest extends AbstractRequest
         $data['ClientIPAddress'] = $this->getClientIp();
         $data['ApplyAVSCV2'] = $this->getApplyAVSCV2() ?: 0;
         $data['Apply3DSecure'] = $this->getApply3DSecure() ?: 0;
+        $data['ReferrerID'] = $this->getReferrerId();
 
         // billing details
         $data['BillingFirstnames'] = $card->getBillingFirstName();

--- a/tests/Message/DirectAuthorizeRequestTest.php
+++ b/tests/Message/DirectAuthorizeRequestTest.php
@@ -37,6 +37,7 @@ class DirectAuthorizeRequestTest extends TestCase
         $this->request->setApply3DSecure(3);
         $this->request->setDescription('food');
         $this->request->setClientIp('127.0.0.1');
+        $this->request->setReferrerId('3F7A4119-8671-464F-A091-9E59EB47B80C');
 
         $data = $this->request->getData();
 
@@ -48,6 +49,7 @@ class DirectAuthorizeRequestTest extends TestCase
         $this->assertSame('127.0.0.1', $data['ClientIPAddress']);
         $this->assertSame(2, $data['ApplyAVSCV2']);
         $this->assertSame(3, $data['Apply3DSecure']);
+        $this->assertSame('3F7A4119-8671-464F-A091-9E59EB47B80C', $data['ReferrerID']);
     }
 
     public function testGetDataCustomerDetails()

--- a/tests/Message/DirectAuthorizeRequestTest.php
+++ b/tests/Message/DirectAuthorizeRequestTest.php
@@ -52,6 +52,16 @@ class DirectAuthorizeRequestTest extends TestCase
         $this->assertSame('3F7A4119-8671-464F-A091-9E59EB47B80C', $data['ReferrerID']);
     }
 
+    public function testGetDataNoReferrerId()
+    {
+        // Default value is equivalent to this:
+        $this->request->setReferrerId('');
+
+        $data = $this->request->getData();
+
+        $this->assertArrayNotHasKey('ReferrerID', $data);
+    }
+
     public function testGetDataCustomerDetails()
     {
         $card = $this->request->getCard();


### PR DESCRIPTION
This pull request provided support for the ReferrerID field.

This can be set at the gateway level (so it can form a part of the gateway account details) and is used in authorization and payment transaction requests. It defaults to "" (no referrer ID).