### PR TITLE
Support SagePay Protocol v3.00

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ The following gateways are provided by this package:
 
 * SagePay_Direct
 * SagePay_Server
+* SagePay_Direct3
+* SagePay_Server3
 
 For general usage instructions, please see the main [Omnipay](https://github.com/thephpleague/omnipay)
 repository.

--- a/src/DirectGateway.php
+++ b/src/DirectGateway.php
@@ -41,6 +41,8 @@ class DirectGateway extends AbstractGateway
     }
 
     // Access to the HTTP client for debugging.
+    // NOTE: this is likely to be removed or replaced with something
+    // more appropriate.
 
     public function getHttpClient()
     {

--- a/src/DirectGateway.php
+++ b/src/DirectGateway.php
@@ -13,6 +13,8 @@ use Omnipay\SagePay\Message\RefundRequest;
  */
 class DirectGateway extends AbstractGateway
 {
+    // Gateway identification.
+
     public function getName()
     {
         return 'Sage Pay Direct';
@@ -26,6 +28,8 @@ class DirectGateway extends AbstractGateway
         );
     }
 
+    // Vendor identification.
+
     public function getVendor()
     {
         return $this->getParameter('vendor');
@@ -35,6 +39,15 @@ class DirectGateway extends AbstractGateway
     {
         return $this->setParameter('vendor', $value);
     }
+
+    // Access to the HTTP client for debugging.
+
+    public function getHttpClient()
+    {
+        return $this->httpClient;
+    }
+
+    // Available services.
 
     public function authorize(array $parameters = array())
     {

--- a/src/DirectGateway.php
+++ b/src/DirectGateway.php
@@ -23,7 +23,6 @@ class DirectGateway extends AbstractGateway
         return array(
             'vendor' => '',
             'testMode' => false,
-            'simulatorMode' => false,
         );
     }
 
@@ -35,16 +34,6 @@ class DirectGateway extends AbstractGateway
     public function setVendor($value)
     {
         return $this->setParameter('vendor', $value);
-    }
-
-    public function getSimulatorMode()
-    {
-        return $this->getParameter('simulatorMode');
-    }
-
-    public function setSimulatorMode($value)
-    {
-        return $this->setParameter('simulatorMode', $value);
     }
 
     public function authorize(array $parameters = array())

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -2,6 +2,8 @@
 
 namespace Omnipay\SagePay\Message;
 
+use Omnipay\Common\Exception\InvalidRequestException;
+
 /**
  * Sage Pay Abstract Request
  */
@@ -9,7 +11,6 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
 {
     protected $liveEndpoint = 'https://live.sagepay.com/gateway/service';
     protected $testEndpoint = 'https://test.sagepay.com/gateway/service';
-    protected $simulatorEndpoint = 'https://test.sagepay.com/Simulator';
 
     public function getVendor()
     {
@@ -19,16 +20,6 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     public function setVendor($value)
     {
         return $this->setParameter('vendor', $value);
-    }
-
-    public function getSimulatorMode()
-    {
-        return $this->getParameter('simulatorMode');
-    }
-
-    public function setSimulatorMode($value)
-    {
-        return $this->setParameter('simulatorMode', $value);
     }
 
     public function getService()
@@ -102,7 +93,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     protected function getBaseData()
     {
         $data = array();
-        $data['VPSProtocol'] = '2.23';
+        $data['VPSProtocol'] = '3.00';
         $data['TxType'] = $this->action;
         $data['Vendor'] = $this->getVendor();
         $data['AccountType'] = $this->getAccountType() ?: 'E';
@@ -120,19 +111,6 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     public function getEndpoint()
     {
         $service = strtolower($this->getService());
-
-        if ($this->getSimulatorMode()) {
-            // hooray for consistency
-            if ($service == 'vspdirect-register') {
-                return $this->simulatorEndpoint.'/VSPDirectGateway.asp';
-            } elseif ($service == 'vspserver-register') {
-                return $this->simulatorEndpoint.'/VSPServerGateway.asp?Service=VendorRegisterTx';
-            } elseif ($service == 'direct3dcallback') {
-                return $this->simulatorEndpoint.'/VSPDirectCallback.asp';
-            }
-
-            return $this->simulatorEndpoint.'/VSPServerGateway.asp?Service=Vendor'.ucfirst($service).'Tx';
-        }
 
         if ($this->getTestMode()) {
             return $this->testEndpoint."/$service.vsp";

--- a/src/Message/ServerCompleteAuthorizeRequest.php
+++ b/src/Message/ServerCompleteAuthorizeRequest.php
@@ -34,7 +34,6 @@ class ServerCompleteAuthorizeRequest extends AbstractRequest
             $this->httpRequest->request->get('PayerStatus').
             $this->httpRequest->request->get('CardType').
             $this->httpRequest->request->get('Last4Digits').
-
             // New for protocol v3.00
             // Described in the docs as "mandatory" but not supplied when PayPal is used,
             // so provide the defaults.

--- a/src/Message/ServerCompleteAuthorizeRequest.php
+++ b/src/Message/ServerCompleteAuthorizeRequest.php
@@ -33,7 +33,15 @@ class ServerCompleteAuthorizeRequest extends AbstractRequest
             $this->httpRequest->request->get('AddressStatus').
             $this->httpRequest->request->get('PayerStatus').
             $this->httpRequest->request->get('CardType').
-            $this->httpRequest->request->get('Last4Digits')
+            $this->httpRequest->request->get('Last4Digits').
+
+            // New for protocol v3.00
+            // Described in the docs as "mandatory" but not supplied when PayPal is used,
+            // so provide the defaults.
+            $this->httpRequest->request->get('DeclineCode', '').
+            $this->httpRequest->request->get('ExpiryDate', '').
+            $this->httpRequest->request->get('FraudResponse', '').
+            $this->httpRequest->request->get('BankAuthCode', '')
         );
 
         if (strtolower($this->httpRequest->request->get('VPSSignature')) !== $signature) {

--- a/src/Message/ServerCompleteAuthorizeRequest.php
+++ b/src/Message/ServerCompleteAuthorizeRequest.php
@@ -9,14 +9,25 @@ use Omnipay\Common\Exception\InvalidResponseException;
  */
 class ServerCompleteAuthorizeRequest extends AbstractRequest
 {
-    public function getData()
+    /**
+     * Get the signature calculated from the three pieces of saved local
+     * information:
+     * * VendorTxCode - merchant site ID (aka transactionId).
+     * * VPSTxId - SagePay ID (aka transactionReference)
+     * * SecurityKey - SagePay one-use token.
+     * and the POSTed transaction results.
+     * Note that the three items above are passed in as a single JSON structure
+     * as the transactionReference. Would be nice if that were just the fallback,
+     * if not passed in as three separate items to the relevant fields.
+     */
+    public function getSignature()
     {
         $this->validate('transactionId', 'transactionReference');
 
         $reference = json_decode($this->getTransactionReference(), true);
 
-        // validate VPSSignature
-        $signature = md5(
+        // Re-create the VPSSignature
+        $signature_string =
             $reference['VPSTxId'].
             $reference['VendorTxCode'].
             $this->httpRequest->request->get('Status').
@@ -40,8 +51,17 @@ class ServerCompleteAuthorizeRequest extends AbstractRequest
             $this->httpRequest->request->get('DeclineCode', '').
             $this->httpRequest->request->get('ExpiryDate', '').
             $this->httpRequest->request->get('FraudResponse', '').
-            $this->httpRequest->request->get('BankAuthCode', '')
-        );
+            $this->httpRequest->request->get('BankAuthCode', '');
+
+        return md5($signature_string);
+    }
+
+    /**
+     * Get the POSTed data, checking that the signature is valid.
+     */
+    public function getData()
+    {
+        $signature = $this->getSignature();
 
         if (strtolower($this->httpRequest->request->get('VPSSignature')) !== $signature) {
             throw new InvalidResponseException;

--- a/tests/Message/ServerAuthorizeResponseTest.php
+++ b/tests/Message/ServerAuthorizeResponseTest.php
@@ -42,6 +42,6 @@ class ServerAuthorizeResponseTest extends TestCase
         $this->assertFalse($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
         $this->assertSame('{"VendorTxCode":"123456"}', $response->getTransactionReference());
-        $this->assertSame('The Description field should be between 1 and 100 characters long.', $response->getMessage());
+        $this->assertSame('3082 : The Description value is too long.', $response->getMessage());
     }
 }

--- a/tests/Message/ServerCompleteAuthorizeResponseTest.php
+++ b/tests/Message/ServerCompleteAuthorizeResponseTest.php
@@ -25,6 +25,9 @@ class ServerCompleteAuthorizeResponseTest extends TestCase
                 'PayerStatus' => 'k',
                 'CardType' => 'l',
                 'Last4Digits' => 'm',
+                'DeclineCode' => '00',
+                'ExpiryDate' => '0722',
+                'BankAuthCode' => '999777',
             )
         );
 

--- a/tests/Mock/CaptureFailure.txt
+++ b/tests/Mock/CaptureFailure.txt
@@ -8,6 +8,6 @@ Content-Type: Text/Plain
 Set-Cookie: ASPSESSIONIDSEHSCTTR=NNBHGPBDLOMKKPGPNDDJFBAB; secure; path=/
 Cache-control: private
 
-VPSProtocol=2.23
+VPSProtocol=3.00
 Status=INVALID
 StatusDetail=You are trying to RELEASE a transaction that has already been RELEASEd or ABORTed.

--- a/tests/Mock/CaptureSuccess.txt
+++ b/tests/Mock/CaptureSuccess.txt
@@ -8,6 +8,6 @@ Content-Type: Text/Plain
 Set-Cookie: ASPSESSIONIDSEHSCTTR=FNBHGPBDMGDJCNLCDCDPGKCA; secure; path=/
 Cache-control: private
 
-VPSProtocol=2.23
+VPSProtocol=3.00
 Status=OK
 StatusDetail=The transaction was RELEASEed successfully.

--- a/tests/Mock/DirectPurchase3dSecure.txt
+++ b/tests/Mock/DirectPurchase3dSecure.txt
@@ -8,7 +8,7 @@ Content-Type: Text/Plain
 Set-Cookie: ASPSESSIONIDSEHSCTTR=FDNGGPBDBPAHLBIMINACENLN; secure; path=/
 Cache-control: private
 
-VPSProtocol=2.23
+VPSProtocol=3.00
 Status=3DAUTH
 3DSecureStatus=OK
 MD=065379457749061954

--- a/tests/Mock/DirectPurchaseFailure.txt
+++ b/tests/Mock/DirectPurchaseFailure.txt
@@ -8,6 +8,6 @@ Content-Type: Text/Plain
 Set-Cookie: ASPSESSIONIDSEHSCTTR=PIMGGPBDEAHAGKNHFGMICIAM; secure; path=/
 Cache-control: private
 
-VPSProtocol=2.23
+VPSProtocol=3.00
 Status=INVALID
 StatusDetail=The VendorTxCode '984297' has been used before.  Each transaction you send should have a unique VendorTxCode.

--- a/tests/Mock/DirectPurchaseSuccess.txt
+++ b/tests/Mock/DirectPurchaseSuccess.txt
@@ -8,7 +8,7 @@ Content-Type: Text/Plain
 Set-Cookie: ASPSESSIONIDSEHSCTTR=CIMGGPBDFDIKICAGIIHCNFHJ; secure; path=/
 Cache-control: private
 
-VPSProtocol=2.23
+VPSProtocol=3.00
 Status=OK
 StatusDetail=Direct transaction from Simulator.
 VPSTxId={5A1BC414-5409-48DD-9B8B-DCDF096CE0BE}

--- a/tests/Mock/ServerPurchaseFailure.txt
+++ b/tests/Mock/ServerPurchaseFailure.txt
@@ -8,6 +8,6 @@ Content-Type: Text/Plain
 Set-Cookie: ASPSESSIONIDSEHSCTTR=EODHGPBDGNKCCIGEMFBBCBPD; secure; path=/
 Cache-control: private
 
-VPSProtocol=2.23
+VPSProtocol=3.00
 Status=INVALID
 StatusDetail=The Description field should be between 1 and 100 characters long.

--- a/tests/Mock/ServerPurchaseFailure.txt
+++ b/tests/Mock/ServerPurchaseFailure.txt
@@ -1,13 +1,11 @@
 HTTP/1.1 200 OK
-Date: Sat, 16 Feb 2013 08:59:41 GMT
-Server: Microsoft-IIS/6.0
 P3P: CP="CUR"
-X-Powered-By: ASP.NET
-Content-Length: 113
-Content-Type: Text/Plain
-Set-Cookie: ASPSESSIONIDSEHSCTTR=EODHGPBDGNKCCIGEMFBBCBPD; secure; path=/
-Cache-control: private
+Content-Language: en-GB
+Content-Length: 88
+Date: Tue, 20 Jan 2015 16:45:41 GMT
+Server: undisclosed
+Set-Cookie: NSC_WRE-uftu.tbhfqbz.dpn-Kbwb7=f76fde52445f8236609ebb88e4554f525455a4a4d5e0;path=/;secure;httponly
 
 VPSProtocol=3.00
 Status=INVALID
-StatusDetail=The Description field should be between 1 and 100 characters long.
+StatusDetail=3082 : The Description value is too long.

--- a/tests/Mock/ServerPurchaseSuccess.txt
+++ b/tests/Mock/ServerPurchaseSuccess.txt
@@ -8,7 +8,7 @@ Content-Type: Text/Plain
 Set-Cookie: ASPSESSIONIDSEHSCTTR=JAEHGPBDBOBICGBGJEHFJHPE; secure; path=/
 Cache-control: private
 
-VPSProtocol=2.23
+VPSProtocol=3.00
 Status=OK
 StatusDetail=Server transaction registered successfully.
 VPSTxId={1E7D9C70-DBE2-4726-88EA-D369810D801D}

--- a/tests/ServerGatewayTest.php
+++ b/tests/ServerGatewayTest.php
@@ -76,14 +76,24 @@ class ServerGatewayTest extends GatewayTestCase
                 'PayerStatus' => 'k',
                 'CardType' => 'l',
                 'Last4Digits' => 'm',
-                'VPSSignature' => md5('{F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2}438791OKbexamplecJEUPDN1N7Edefghijklm'),
+                // New fields for protocol v3.00
+                'DeclineCode' => '00',
+                'ExpiryDate' => '0722',
+                'BankAuthCode' => '999777',
+                'VPSSignature' => md5(
+                    '{F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2}'
+                    . '438791' . 'OK' . 'bexamplecJEUPDN1N7Edefghijklm' . '00' . '0722' . '999777'
+                ),
             )
         );
 
         $response = $this->gateway->completeAuthorize($this->completePurchaseOptions)->send();
 
         $this->assertTrue($response->isSuccessful());
-        $this->assertSame('{"SecurityKey":"JEUPDN1N7E","TxAuthNo":"b","VPSTxId":"{F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2}","VendorTxCode":"123"}', $response->getTransactionReference());
+        $this->assertSame(
+            '{"SecurityKey":"JEUPDN1N7E","TxAuthNo":"b","VPSTxId":"{F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2}","VendorTxCode":"123"}',
+            $response->getTransactionReference()
+        );
         $this->assertNull($response->getMessage());
     }
 

--- a/tests/ServerGatewayTest.php
+++ b/tests/ServerGatewayTest.php
@@ -6,6 +6,8 @@ use Omnipay\Tests\GatewayTestCase;
 
 class ServerGatewayTest extends GatewayTestCase
 {
+    protected $error_3082_text = '3082 : The Description value is too long.';
+
     public function setUp()
     {
         parent::setUp();
@@ -54,7 +56,7 @@ class ServerGatewayTest extends GatewayTestCase
         $this->assertFalse($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
         $this->assertSame('{"VendorTxCode":"123"}', $response->getTransactionReference());
-        $this->assertSame('The Description field should be between 1 and 100 characters long.', $response->getMessage());
+        $this->assertSame($this->error_3082_text, $response->getMessage());
     }
 
     public function testCompleteAuthorizeSuccess()
@@ -115,7 +117,7 @@ class ServerGatewayTest extends GatewayTestCase
         $this->assertFalse($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
         $this->assertSame('{"VendorTxCode":"123"}', $response->getTransactionReference());
-        $this->assertSame('The Description field should be between 1 and 100 characters long.', $response->getMessage());
+        $this->assertSame($this->error_3082_text, $response->getMessage());
     }
 
     public function testCompletePurchaseSuccess()


### PR DESCRIPTION
This updates the protocol from 2.23 to 3.00. The main changes are:

* Removal of the "simulalator mode" as that is not supported by protocol v3.00. However,, if that comes back - and it may - then we (I) can put it back in.
* Update of the protocol version POSTed to "3.00".
* Updated appropriate tests.
* Extended the callback VPS signature check to include four new fields listed as mandatory for v.3.00 (DeclineCode, ExpiryDate, FraudResponse, BankAuthCode)

Before this PR is merged, I would recommend making a final release of current V2 dev-master, taking a "2.x" branch to incorporate that release, then merging and releasing as 3.0.0 (or thereabouts). We still may need to be able to support security patches for people still stuck on protocol 2.23, for the next few months at least, until SagePay switch that version off. A separate 2.x branch will allow us to do that, and also won't be bumping people up to protocol v3.00 unexpectedly (though TBH I don't think they would notice, but you never know).

Edit: with end-to-end tests, in my callback I have received these additional fields on a successful authorisation:

    "DeclineCode":"00","ExpiryDate":"0722","BankAuthCode":"999777"

These new fields are all incorporated with the signature check, and it did not fail. I will get these into the tests though, but maybe in a separate PR (we have never tested the notification callback signature check, so far as I can tell, so nothing here has changed).