### PR TITLE
Typo in README - two non-existent driver names removed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ The following gateways are provided by this package:
 
 * SagePay_Direct
 * SagePay_Server
-* SagePay_Direct3
-* SagePay_Server3
 
 For general usage instructions, please see the main [Omnipay](https://github.com/thephpleague/omnipay)
 repository.


### PR DESCRIPTION
Minor typo in the README got overlooked.