### PR TITLE
Fix for issue #20

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -112,6 +112,11 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
 
     public function sendData($data)
     {
+        // Issue #20 no data values should be null.
+        array_walk($data, function(&$value) {
+            if (!isset($value)) $value = '';
+        });
+
         $httpResponse = $this->httpClient->post($this->getEndpoint(), null, $data)->send();
 
         return $this->createResponse($httpResponse->getBody());

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -117,8 +117,10 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     public function sendData($data)
     {
         // Issue #20 no data values should be null.
-        array_walk($data, function(&$value) {
-            if (!isset($value)) $value = '';
+        array_walk($data, function (&$value) {
+            if (!isset($value)) {
+                $value = '';
+            }
         });
 
         $httpResponse = $this->httpClient->post($this->getEndpoint(), null, $data)->send();

--- a/tests/Message/DirectAuthorizeRequestTest.php
+++ b/tests/Message/DirectAuthorizeRequestTest.php
@@ -125,4 +125,22 @@ class DirectAuthorizeRequestTest extends TestCase
 
         $this->assertSame('dc', $data['CardType']);
     }
+
+    public function testGetDataNullBillingAddress2()
+    {
+        $card = $this->request->getCard();
+
+        // This emulates not setting the billing address 2 at all
+        // (it defaults to null).
+        $card->setBillingAddress2(null);
+
+        $data = $this->request->getData();
+
+        $this->assertNull($data['BillingAddress2']);
+
+        // This tests that the BillingAddress2 may be left unset,
+        // which defaults to null. When it is sent to SagePay, it gets
+        // converted to an empty string. I'm not clear how that would be
+        // tested.
+    }
 }


### PR DESCRIPTION
Before data is sent to Guzzle, any null parameters are set to empty strings. This will ensure all POST parameters have an "=" appended. Whether SagePay has been fixed to accept parameter `foo` as equivalent to parameter `foo=` or not, this fix will do no harm. 

This fix could do with an additional test, but I will need guidance on how that would work. Basically, given a BillingAddress2 set to null, the assertion is that the POST parameters sent to Guzzle should include the element `"BillingAddress2" => ""` and not `"BillingAddress2" => null`.