### PR TITLE
 Extended response methods to optionally return

### DIFF
--- a/src/Message/ServerCompleteAuthorizeResponse.php
+++ b/src/Message/ServerCompleteAuthorizeResponse.php
@@ -35,10 +35,12 @@ class ServerCompleteAuthorizeResponse extends Response
      * @param string URL to forward the customer to. Note this is different to your standard
      *               return controller action URL.
      * @param string Optional human readable reasons for accepting the transaction.
+     * @param bool   Return the response as a string rather than sending it and exiting the
+     *               program.
      */
-    public function confirm($nextUrl, $detail = null)
+    public function confirm($nextUrl, $detail = null, $return = false)
     {
-        $this->sendResponse('OK', $nextUrl, $detail);
+        return $this->sendResponse('OK', $nextUrl, $detail, $return);
     }
 
     /**
@@ -51,10 +53,12 @@ class ServerCompleteAuthorizeResponse extends Response
      * @param string URL to foward the customer to. Note this is different to your standard
      *               return controller action URL.
      * @param string Optional human readable reasons for not accepting the transaction.
+     * @param bool   Return the response as a string rather than sending it and exiting the
+     *               program.
      */
-    public function error($nextUrl, $detail = null)
+    public function error($nextUrl, $detail = null, $return = false)
     {
-        $this->sendResponse('ERROR', $nextUrl, $detail);
+        return $this->sendResponse('ERROR', $nextUrl, $detail, $return);
     }
 
     /**
@@ -68,10 +72,12 @@ class ServerCompleteAuthorizeResponse extends Response
      * @param string URL to foward the customer to. Note this is different to your standard
      *               return controller action URL.
      * @param string Optional human readable reasons for not accepting the transaction.
+     * @param bool   Return the response as a string rather than sending it and exiting the
+     *               program.
      */
-    public function invalid($nextUrl, $detail = null)
+    public function invalid($nextUrl, $detail = null, $return = false)
     {
-        $this->sendResponse('INVALID', $nextUrl, $detail);
+        return $this->sendResponse('INVALID', $nextUrl, $detail, $return);
     }
 
     /**
@@ -93,13 +99,19 @@ class ServerCompleteAuthorizeResponse extends Response
      * @param string URL to forward the customer to. Note this is different to your standard
      *               return controller action URL.
      * @param string Optional human readable reasons for accepting the transaction.
+     * @param bool   If set to true, this method will return the response as a string and not
+     *               exit the program.
      */
-    public function sendResponse($status, $nextUrl, $detail = null)
+    public function sendResponse($status, $nextUrl, $detail = null, $return = false)
     {
         $message = "Status=$status\r\nRedirectUrl=$nextUrl";
 
         if (null !== $detail) {
             $message .= "\r\nStatusDetail=".$detail;
+        }
+
+        if ($return) {
+            return $message;
         }
 
         $this->exitWith($message);

--- a/tests/Message/ServerCompleteAuthorizeResponseTest.php
+++ b/tests/Message/ServerCompleteAuthorizeResponseTest.php
@@ -53,25 +53,49 @@ class ServerCompleteAuthorizeResponseTest extends TestCase
     public function testConfirm()
     {
         $response = m::mock('\Omnipay\SagePay\Message\ServerCompleteAuthorizeResponse')->makePartial();
-        $response->shouldReceive('sendResponse')->once()->with('OK', 'https://www.example.com/', 'detail');
+        $response->shouldReceive('sendResponse')->once()->with('OK', 'https://www.example.com/', 'detail', false);
 
         $response->confirm('https://www.example.com/', 'detail');
+    }
+
+    public function testConfirmWithReturn()
+    {
+        $response = m::mock('\Omnipay\SagePay\Message\ServerCompleteAuthorizeResponse')->makePartial();
+        $response->shouldReceive('sendResponse')->once()->with('OK', 'https://www.example.com/', 'detail', true);
+
+        $response->confirm('https://www.example.com/', 'detail', true);
     }
 
     public function testError()
     {
         $response = m::mock('\Omnipay\SagePay\Message\ServerCompleteAuthorizeResponse')->makePartial();
-        $response->shouldReceive('sendResponse')->once()->with('ERROR', 'https://www.example.com/', 'detail');
+        $response->shouldReceive('sendResponse')->once()->with('ERROR', 'https://www.example.com/', 'detail', false);
 
         $response->error('https://www.example.com/', 'detail');
+    }
+
+    public function testErrorWithReturn()
+    {
+        $response = m::mock('\Omnipay\SagePay\Message\ServerCompleteAuthorizeResponse')->makePartial();
+        $response->shouldReceive('sendResponse')->once()->with('ERROR', 'https://www.example.com/', 'detail', true);
+
+        $response->error('https://www.example.com/', 'detail', true);
     }
 
     public function testInvalid()
     {
         $response = m::mock('\Omnipay\SagePay\Message\ServerCompleteAuthorizeResponse')->makePartial();
-        $response->shouldReceive('sendResponse')->once()->with('INVALID', 'https://www.example.com/', 'detail');
+        $response->shouldReceive('sendResponse')->once()->with('INVALID', 'https://www.example.com/', 'detail', false);
 
         $response->invalid('https://www.example.com/', 'detail');
+    }
+
+    public function testInvalid()
+    {
+        $response = m::mock('\Omnipay\SagePay\Message\ServerCompleteAuthorizeResponse')->makePartial();
+        $response->shouldReceive('sendResponse')->once()->with('INVALID', 'https://www.example.com/', 'detail', true);
+
+        $response->invalid('https://www.example.com/', 'detail', true);
     }
 
     public function testSendResponse()
@@ -88,5 +112,14 @@ class ServerCompleteAuthorizeResponseTest extends TestCase
         $response->shouldReceive('exitWith')->once()->with("Status=FOO\r\nRedirectUrl=https://www.example.com/\r\nStatusDetail=Bar");
 
         $response->sendResponse('FOO', 'https://www.example.com/', 'Bar');
+    }
+
+    public function testSendResponseDetailWithReturn()
+    {
+        $response = m::mock('\Omnipay\SagePay\Message\ServerCompleteAuthorizeResponse')->makePartial();
+
+        $responseString = $response->sendResponse('FOO', 'https://www.example.com/', 'Bar', true);
+
+        $this->assertEquals("Status=FOO\r\nRedirectUrl=https://www.example.com/\r\nStatusDetail=Bar", $responseString);
     }
 }

--- a/tests/Message/ServerCompleteAuthorizeResponseTest.php
+++ b/tests/Message/ServerCompleteAuthorizeResponseTest.php
@@ -90,7 +90,7 @@ class ServerCompleteAuthorizeResponseTest extends TestCase
         $response->invalid('https://www.example.com/', 'detail');
     }
 
-    public function testInvalid()
+    public function testInvalidWithReturn()
     {
         $response = m::mock('\Omnipay\SagePay\Message\ServerCompleteAuthorizeResponse')->makePartial();
         $response->shouldReceive('sendResponse')->once()->with('INVALID', 'https://www.example.com/', 'detail', true);


### PR DESCRIPTION
Added an optional parameter to allow the methods (confirm, error, invalid, sendResponse) to return the response as a string rather than exit the program.

This allows for a cleaner integration with frameworks that deal in Request-Response objects.