### PR TITLE
Add support for the SurchargeXML parameter in server purchase requests

### DIFF
--- a/src/Message/ServerPurchaseRequest.php
+++ b/src/Message/ServerPurchaseRequest.php
@@ -12,12 +12,12 @@ class ServerPurchaseRequest extends ServerAuthorizeRequest
 
     public function setSurchargeXml($surchargeXml)
     {
-        $this->setParameter('SurchargeXML', $surchargeXml);
+        $this->setParameter('surchargeXml', $surchargeXml);
     }
 
     public function getSurchargeXml()
     {
-        return $this->getParameter('SurchargeXML');
+        return $this->getParameter('surchargeXml');
     }
 
     public function getData()
@@ -25,12 +25,10 @@ class ServerPurchaseRequest extends ServerAuthorizeRequest
         $data = parent::getData();
 
         $surchargeXml = $this->getSurchargeXml();
-        if($surchargeXml)
-        {
-            $data['SurchargeXML'] = $this->getSurchargeXml();
+        if ($surchargeXml) {
+            $data['surchargeXml'] = $this->getSurchargeXml();
         }
 
         return $data;
     }
-
 }

--- a/src/Message/ServerPurchaseRequest.php
+++ b/src/Message/ServerPurchaseRequest.php
@@ -8,4 +8,28 @@ namespace Omnipay\SagePay\Message;
 class ServerPurchaseRequest extends ServerAuthorizeRequest
 {
     protected $action = 'PAYMENT';
+
+    public function setSurchargeXml($surchargeXml)
+    {
+        $this->setParameter('SurchargeXML', $surchargeXml);
+    }
+
+    public function getSurchargeXml()
+    {
+        return $this->getParameter('SurchargeXML');
+    }
+
+    public function getData()
+    {
+        $data = parent::getData();
+
+        $surchargeXml = $this->getSurchargeXml();
+        if($surchargeXml){
+            $data['SurchargeXML'] = $this->getSurchargeXml();
+        }
+
+        return $data;
+    }
+
+
 }

--- a/src/Message/ServerPurchaseRequest.php
+++ b/src/Message/ServerPurchaseRequest.php
@@ -7,6 +7,7 @@ namespace Omnipay\SagePay\Message;
  */
 class ServerPurchaseRequest extends ServerAuthorizeRequest
 {
+
     protected $action = 'PAYMENT';
 
     public function setSurchargeXml($surchargeXml)
@@ -30,6 +31,5 @@ class ServerPurchaseRequest extends ServerAuthorizeRequest
 
         return $data;
     }
-
 
 }

--- a/src/Message/ServerPurchaseRequest.php
+++ b/src/Message/ServerPurchaseRequest.php
@@ -25,7 +25,8 @@ class ServerPurchaseRequest extends ServerAuthorizeRequest
         $data = parent::getData();
 
         $surchargeXml = $this->getSurchargeXml();
-        if($surchargeXml){
+        if($surchargeXml)
+        {
             $data['SurchargeXML'] = $this->getSurchargeXml();
         }
 

--- a/tests/Message/ServerPurchaseRequestTest.php
+++ b/tests/Message/ServerPurchaseRequestTest.php
@@ -26,7 +26,7 @@ class ServerPurchaseRequestTest extends TestCase
         $this->assertSame(self::SURCHARGE_XML, $data['surchargeXml']);
     }
 
-    public function setSetSurchargeXml()
+    public function testSetSurchargeXml()
     {
         $request = new ServerPurchaseRequest($this->getHttpClient(), $this->getHttpRequest());
         $request->initialize(

--- a/tests/Message/ServerPurchaseRequestTest.php
+++ b/tests/Message/ServerPurchaseRequestTest.php
@@ -17,13 +17,13 @@ class ServerPurchaseRequestTest extends TestCase
                 'returnUrl' => 'http://www.example.com/return',
                 'amount' => '12.00',
                 'transactionId' => '123',
-                'SurchargeXML' => self::SURCHARGE_XML,
+                'surchargeXml' => self::SURCHARGE_XML,
                 'card' => $this->getValidCard(),
             )
         );
 
         $data = $request->getData();
-        $this->assertSame(self::SURCHARGE_XML, $data['SurchargeXML']);
+        $this->assertSame(self::SURCHARGE_XML, $data['surchargeXml']);
     }
 
     public function setSetSurchargeXml()
@@ -41,7 +41,7 @@ class ServerPurchaseRequestTest extends TestCase
         $request->setSurchargeXml(self::SURCHARGE_XML);
 
         $data = $request->getData();
-        $this->assertSame(self::SURCHARGE_XML, $data['SurchargeXML']);
+        $this->assertSame(self::SURCHARGE_XML, $data['surchargeXml']);
     }
 
 }

--- a/tests/Message/ServerPurchaseRequestTest.php
+++ b/tests/Message/ServerPurchaseRequestTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Omnipay\SagePay\Message;
+
+use Omnipay\Tests\TestCase;
+
+class ServerPurchaseRequestTest extends TestCase
+{
+
+    const SURCHARGE_XML = '<surcharges><surcharge><paymentType>VISA</paymentType><percentage>2.50</percentage></surcharge></surcharges>';
+
+    public function testInitialize()
+    {
+        $request = new ServerPurchaseRequest($this->getHttpClient(), $this->getHttpRequest());
+        $request->initialize(
+            array(
+                'returnUrl' => 'http://www.example.com/return',
+                'amount' => '12.00',
+                'transactionId' => '123',
+                'SurchargeXML' => self::SURCHARGE_XML,
+                'card' => $this->getValidCard(),
+            )
+        );
+
+        $data = $request->getData();
+        $this->assertSame(self::SURCHARGE_XML, $data['SurchargeXML']);
+    }
+
+    public function setSetSurchargeXml()
+    {
+        $request = new ServerPurchaseRequest($this->getHttpClient(), $this->getHttpRequest());
+        $request->initialize(
+            array(
+                'returnUrl' => 'https://www.example.com/return',
+                'amount' => '12.00',
+                'transactionId' => '123',
+                'card' => $this->getValidCard(),
+            )
+        );
+
+        $request->setSurchargeXml(self::SURCHARGE_XML);
+
+        $data = $request->getData();
+        $this->assertSame(self::SURCHARGE_XML, $data['SurchargeXML']);
+    }
+
+}


### PR DESCRIPTION
When attempting to pass the SurchargeXML parameter in a server purchase request, I noticed it wasn't making it through to SagePay.

http://www.sagepay.co.uk/support/12/36/protocol-3-00-surcharge-xml

This PR includes the parameter and provides a getter and setter to allow it to be modified after initialize() has been called.
