### PR TITLE
Added new payment request for deferred payments

### DIFF
--- a/src/Message/ServerDeferredPurchaseRequest.php
+++ b/src/Message/ServerDeferredPurchaseRequest.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Omnipay\SagePay\Message;
+
+/**
+ * Sage Pay Server Deferred payment Request
+ */
+class ServerDeferredPurchaseRequest extends ServerPurchaseRequest
+{
+    protected $action = 'DEFERRED';
+}

--- a/src/ServerGateway.php
+++ b/src/ServerGateway.php
@@ -31,6 +31,11 @@ class ServerGateway extends DirectGateway
         return $this->createRequest('\Omnipay\SagePay\Message\ServerPurchaseRequest', $parameters);
     }
 
+    public function deferredPurchase(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\SagePay\Message\ServerDeferredPurchaseRequest', $parameters);
+    }
+
     public function completePurchase(array $parameters = array())
     {
         return $this->completeAuthorize($parameters);

--- a/tests/ServerGatewayTest.php
+++ b/tests/ServerGatewayTest.php
@@ -129,8 +129,9 @@ class ServerGatewayTest extends GatewayTestCase
         /** @var ServerPurchaseRequest $request */
         $request = $this->gateway->purchase($this->purchaseOptions);
 
-        $this->assertArrayHasKey('TxType', $request->getData(), "TxType is not included in the request");
-        $this->assertEquals('PAYMENT', $request->getData()['TxType'], 'TxType does not equal PAYMENT');
+        $requestData = $request->getData();
+        $this->assertArrayHasKey('TxType', $requestData, "TxType is not included in the request");
+        $this->assertEquals('PAYMENT', $requestData['TxType'], 'TxType does not equal PAYMENT');
 
         $response = $request->send();
 
@@ -148,8 +149,9 @@ class ServerGatewayTest extends GatewayTestCase
         /** @var ServerPurchaseRequest $request */
         $request = $this->gateway->purchase($this->purchaseOptions);
 
-        $this->assertArrayHasKey('TxType', $request->getData(), "TxType is not included in the request");
-        $this->assertEquals('PAYMENT', $request->getData()['TxType'], 'TxType does not equal PAYMENT');
+        $requestData = $request->getData();
+        $this->assertArrayHasKey('TxType', $requestData, "TxType is not included in the request");
+        $this->assertEquals('PAYMENT', $requestData['TxType'], 'TxType does not equal PAYMENT');
 
         $response = $request->send();
 
@@ -194,8 +196,9 @@ class ServerGatewayTest extends GatewayTestCase
         /** @var ServerDeferredPurchaseRequest $request */
         $request = $this->gateway->deferredPurchase($this->purchaseOptions);
 
-        $this->assertArrayHasKey('TxType', $request->getData(), "TxType is not included in the request");
-        $this->assertEquals('DEFERRED', $request->getData()['TxType'], 'TxType does not equal DEFERRED');
+        $requestData = $request->getData();
+        $this->assertArrayHasKey('TxType', $requestData, "TxType is not included in the request");
+        $this->assertEquals('DEFERRED', $requestData['TxType'], 'TxType does not equal DEFERRED');
 
         $response = $request->send();
 
@@ -213,8 +216,9 @@ class ServerGatewayTest extends GatewayTestCase
         /** @var ServerDeferredPurchaseRequest $request */
         $request = $this->gateway->deferredPurchase($this->purchaseOptions);
 
-        $this->assertArrayHasKey('TxType', $request->getData(), "TxType is not included in the request");
-        $this->assertEquals('DEFERRED', $request->getData()['TxType'], 'TxType does not equal DEFERRED');
+        $requestData = $request->getData();
+        $this->assertArrayHasKey('TxType', $requestData, "TxType is not included in the request");
+        $this->assertEquals('DEFERRED', $requestData['TxType'], 'TxType does not equal DEFERRED');
 
         $response = $request->send();
 


### PR DESCRIPTION
It is currently not possible to create a new Sage pay transaction of any type other then PAYMENT when using server integration, this adds the functionality for DEFERRED payments.