### PR TITLE
Add XMLBasket discounts

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -136,32 +136,4 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     {
         return $this->response = new Response($this, $data);
     }
-
-    /**
-     * Add BasketXml to SagePay
-     * implementing BasketXML assigning to $data['BasketXML'] xml structure of the basket
-     * unitGrossAmount should be sum of unitNetAmount and unitTaxAmount
-     * @return array
-     */
-
-    protected function getItemData() {
-
-        $items = $this->getItems();
-        $xml = new \SimpleXMLElement('<basket/>');
-        $data = array();
-        foreach($items as $basketItem) {
-
-            $total = ($basketItem->getQuantity() * $basketItem->getPrice());
-
-            $item = $xml->addChild('item');
-            $item->addChild('description', $basketItem->getName());
-            $item->addChild('quantity', $basketItem->getQuantity());
-            $item->addChild('unitNetAmount', $basketItem->getPrice());
-            $item->addChild('unitTaxAmount', '0.0');
-            $item->addChild('unitGrossAmount', $basketItem->getPrice());
-            $item->addChild('totalGrossAmount', $total);
-        }
-        $data['BasketXML'] = $xml->asXML();
-        return $data;
-    }
 }

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -139,6 +139,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
 
     /**
      * Add BasketXml to SagePay
+     * implementing BasketXML assigning to $data['BasketXML'] xml structure of the basket
      * @return array
      */
 

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -144,24 +144,38 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
      * @return array
      */
 
-    protected function getItemData() {
+    protected function getItemData()
+    {
 
         $items = $this->getItems();
+
         $xml = new \SimpleXMLElement('<basket/>');
         $data = array();
-        foreach($items as $basketItem) {
+        foreach ($items as $basketItem) {
 
-            $total = ($basketItem->getQuantity() * $basketItem->getPrice());
+            if($basketItem->getPrice() < 0) {
+                $discounts = $xml->addChild('discounts');
+                $discount = $discounts->addChild('discount');
+                $discount->addChild('fixed', $basketItem->getPrice() * -1);
+                $discount->addChild('description',$basketItem->getName());
 
-            $item = $xml->addChild('item');
-            $item->addChild('description', $basketItem->getName());
-            $item->addChild('quantity', $basketItem->getQuantity());
-            $item->addChild('unitNetAmount', $basketItem->getPrice());
-            $item->addChild('unitTaxAmount', '0.0');
-            $item->addChild('unitGrossAmount', $basketItem->getPrice());
-            $item->addChild('totalGrossAmount', $total);
+            } else {
+
+                $total = ($basketItem->getQuantity() * $basketItem->getPrice());
+                $item = $xml->addChild('item');
+                $item->addChild('description', $basketItem->getName());
+                $item->addChild('quantity', $basketItem->getQuantity());
+                $item->addChild('unitNetAmount', $basketItem->getPrice());
+                $item->addChild('unitTaxAmount', '0.0');
+                $item->addChild('unitGrossAmount', $basketItem->getPrice());
+                $item->addChild('totalGrossAmount', $total);
+            }
+
+
         }
+
         $data['BasketXML'] = $xml->asXML();
+  
         return $data;
     }
 }

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -136,4 +136,32 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     {
         return $this->response = new Response($this, $data);
     }
+
+    /**
+     * Add BasketXml to SagePay
+     * implementing BasketXML assigning to $data['BasketXML'] xml structure of the basket
+     * unitGrossAmount should be sum of unitNetAmount and unitTaxAmount
+     * @return array
+     */
+
+    protected function getItemData() {
+
+        $items = $this->getItems();
+        $xml = new \SimpleXMLElement('<basket/>');
+        $data = array();
+        foreach($items as $basketItem) {
+
+            $total = ($basketItem->getQuantity() * $basketItem->getPrice());
+
+            $item = $xml->addChild('item');
+            $item->addChild('description', $basketItem->getName());
+            $item->addChild('quantity', $basketItem->getQuantity());
+            $item->addChild('unitNetAmount', $basketItem->getPrice());
+            $item->addChild('unitTaxAmount', '0.0');
+            $item->addChild('unitGrossAmount', $basketItem->getPrice());
+            $item->addChild('totalGrossAmount', $total);
+        }
+        $data['BasketXML'] = $xml->asXML();
+        return $data;
+    }
 }

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -140,6 +140,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     /**
      * Add BasketXml to SagePay
      * implementing BasketXML assigning to $data['BasketXML'] xml structure of the basket
+     * unitGrossAmount should be sum of unitNetAmount and unitTaxAmount
      * @return array
      */
 

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -136,4 +136,25 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     {
         return $this->response = new Response($this, $data);
     }
+
+    protected function getItemData() {
+
+        $items = $this->getItems();
+        $xml = new \SimpleXMLElement('<basket/>');
+        $data = array();
+        foreach($items as $basketItem) {
+
+            $total = ($basketItem->getQuantity() * $basketItem->getPrice());
+
+            $item = $xml->addChild('item');
+            $item->addChild('description', $basketItem->getName());
+            $item->addChild('quantity', $basketItem->getQuantity());
+            $item->addChild('unitNetAmount', $basketItem->getPrice());
+            $item->addChild('unitTaxAmount', '0.0');
+            $item->addChild('unitGrossAmount', $basketItem->getPrice());
+            $item->addChild('totalGrossAmount', $total);
+        }
+        $data['BasketXML'] = $xml->asXML();
+        return $data;
+    }
 }

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -137,6 +137,11 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return $this->response = new Response($this, $data);
     }
 
+    /**
+     * Add BasketXml to SagePay
+     * @return array
+     */
+
     protected function getItemData() {
 
         $items = $this->getItems();

--- a/src/Message/DirectAuthorizeRequest.php
+++ b/src/Message/DirectAuthorizeRequest.php
@@ -54,6 +54,8 @@ class DirectAuthorizeRequest extends AbstractRequest
         $data['DeliveryPhone'] = $card->getShippingPhone();
         $data['CustomerEMail'] = $card->getEmail();
 
+        $data = array_merge($data, $this->getItemData());
+
         return $data;
     }
 

--- a/src/Message/DirectAuthorizeRequest.php
+++ b/src/Message/DirectAuthorizeRequest.php
@@ -53,8 +53,6 @@ class DirectAuthorizeRequest extends AbstractRequest
         $data['DeliveryCountry'] = $card->getShippingCountry();
         $data['DeliveryPhone'] = $card->getShippingPhone();
         $data['CustomerEMail'] = $card->getEmail();
-//merge $data array and $data['BasketXML'] array
-        $data = array_merge($data, $this->getItemData());
 
         return $data;
     }

--- a/src/Message/DirectAuthorizeRequest.php
+++ b/src/Message/DirectAuthorizeRequest.php
@@ -53,7 +53,7 @@ class DirectAuthorizeRequest extends AbstractRequest
         $data['DeliveryCountry'] = $card->getShippingCountry();
         $data['DeliveryPhone'] = $card->getShippingPhone();
         $data['CustomerEMail'] = $card->getEmail();
-
+//merge $data array and $data['BasketXML'] array
         $data = array_merge($data, $this->getItemData());
 
         return $data;

--- a/src/Message/DirectAuthorizeRequest.php
+++ b/src/Message/DirectAuthorizeRequest.php
@@ -54,6 +54,9 @@ class DirectAuthorizeRequest extends AbstractRequest
         $data['DeliveryPhone'] = $card->getShippingPhone();
         $data['CustomerEMail'] = $card->getEmail();
 
+        //merge $data array and $data['BasketXML'] array
+        $data = array_merge($data, $this->getItemData());
+
         return $data;
     }
 


### PR DESCRIPTION
Hello,
We needed for our project xml basket discounts  implementation of SagePay, but unfortunately 
it loks like there is a bug in XMLBasket discounts display on the SagePay admin myacount and we could not see the discounts.
Here is our little change to XML basket discounts and hopefully SagePay will fix the bug soon.
Please can you merge the changes so we could pull and update our omnipay-sagepay driver