### PR TITLE
allow zero value item in basket test for discounts and escaped html c…

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -181,7 +181,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
                 if ($discountItems->getPrice() < 0) {
                     $discount = $discounts->addChild('discount');
                     $discount->addChild('fixed', $discountItems->getPrice() * -1);
-                    $discount->addChild('description')->{0} = $discountItems->getName();
+                    $discount->addChild('description')->{0} = ($discountItems->getName());
                 }
             }
         }

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -178,11 +178,11 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         }
         if ($cartHasDiscounts) {
             $discounts = $xml->addChild('discounts');
-            foreach ($items as $discountItems) {
-                if ($discountItems->getPrice() < 0) {
+            foreach ($items as $discountItem) {
+                if ($discountItem->getPrice() < 0) {
                     $discount = $discounts->addChild('discount');
-                    $discount->addChild('fixed', $discountItems->getPrice() * -1);
-                    $discount->description = $discountItems->getName();
+                    $discount->addChild('fixed', ($discountItem->getPrice() * $discountItem->getQuantity()) * -1);
+                    $discount->description = $discountItem->getName();
                 }
             }
         }

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -182,7 +182,6 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
                     $discount = $discounts->addChild('discount');
                     $discount->addChild('fixed', $discountItems->getPrice() * -1);
                     $discount->description = $discountItems->getName();
-                   // addChild('description', htmlspecialchars($discountItems->getName(), ENT_QUOTES, 'UTF-8'));
                 }
             }
         }

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -159,7 +159,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         $standardChars = "0-9a-zA-Z";
         $allowedSpecialChars = " +'/\\&:,.-{}";
         $pattern = '`[^'.$standardChars.preg_quote($allowedSpecialChars, '/').']`';
-        $name = trim(preg_replace($pattern, '', $name));
+        $name = trim(substr(preg_replace($pattern, '', $name), 0, 100));
 
         return $name;
     }
@@ -179,7 +179,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         $standardChars = "0-9a-zA-Z";
         $allowedSpecialChars = " +'/\\:,.-{};_@()^\"~[]$=!#?|";
         $pattern = '`[^'.$standardChars.preg_quote($allowedSpecialChars, '/').']`';
-        $name = trim(preg_replace($pattern, '', $name));
+        $name = trim(substr(preg_replace($pattern, '', $name), 0, 100));
 
         return $name;
     }

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -181,8 +181,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
                 if ($discountItems->getPrice() < 0) {
                     $discount = $discounts->addChild('discount');
                     $discount->addChild('fixed', $discountItems->getPrice() * -1);
-                    $discount->addChild('description',
-                        htmlspecialchars($discountItems->getName(), ENT_QUOTES, "UTF-8"));
+                    $discount->addChild('description',htmlspecialchars($discountItems->getName(),ENT_QUOTES,"UTF-8"));
                 }
             }
         }

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -181,7 +181,8 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
                 if ($discountItems->getPrice() < 0) {
                     $discount = $discounts->addChild('discount');
                     $discount->addChild('fixed', $discountItems->getPrice() * -1);
-                    $discount->addChild('description',htmlspecialchars($discountItems->getName(),ENT_QUOTES,"UTF-8"));
+                    $discount->
+                    addChild('description', htmlspecialchars($discountItems->getName(), ENT_QUOTES, "UTF-8"));
                 }
             }
         }

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -154,6 +154,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         $result = '';
         $items = $this->getItems();
 
+        // If there are no items, then do not construct any of the basket.
         if (empty($items) || $items->all() === array()) {
             return $result;
         }

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -167,7 +167,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
             } else {
                 $total = ($basketItem->getQuantity() * $basketItem->getPrice());
                 $item = $xml->addChild('item');
-                $item->addChild('description')->{0} = $basketItem->getName();
+                $item->description = $basketItem->getName();
                 $item->addChild('quantity', $basketItem->getQuantity());
                 $item->addChild('unitNetAmount', $basketItem->getPrice());
                 $item->addChild('unitTaxAmount', '0.00');
@@ -181,7 +181,8 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
                 if ($discountItems->getPrice() < 0) {
                     $discount = $discounts->addChild('discount');
                     $discount->addChild('fixed', $discountItems->getPrice() * -1);
-                    $discount->addChild('description')->{0} = ($discountItems->getName());
+                    $discount->description = $discountItems->getName();
+                   // addChild('description', htmlspecialchars($discountItems->getName(), ENT_QUOTES, 'UTF-8'));
                 }
             }
         }

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -167,7 +167,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
             } else {
                 $total = ($basketItem->getQuantity() * $basketItem->getPrice());
                 $item = $xml->addChild('item');
-                $item->addChild('description', htmlspecialchars($basketItem->getName(), ENT_QUOTES, "UTF-8"));
+                $item->addChild('description')->{0} = $basketItem->getName();
                 $item->addChild('quantity', $basketItem->getQuantity());
                 $item->addChild('unitNetAmount', $basketItem->getPrice());
                 $item->addChild('unitTaxAmount', '0.00');
@@ -181,8 +181,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
                 if ($discountItems->getPrice() < 0) {
                     $discount = $discounts->addChild('discount');
                     $discount->addChild('fixed', $discountItems->getPrice() * -1);
-                    $discount->
-                    addChild('description', htmlspecialchars($discountItems->getName(), ENT_QUOTES, "UTF-8"));
+                    $discount->addChild('description')->{0} = $discountItems->getName();
                 }
             }
         }

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -181,7 +181,8 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
                 if ($discountItems->getPrice() < 0) {
                     $discount = $discounts->addChild('discount');
                     $discount->addChild('fixed', $discountItems->getPrice() * -1);
-                    $discount->addChild('description', htmlspecialchars($discountItems->getName(), ENT_QUOTES, "UTF-8"));
+                    $discount->addChild('description',
+                        htmlspecialchars($discountItems->getName(), ENT_QUOTES, "UTF-8"));
                 }
             }
         }

--- a/tests/Message/DirectAuthorizeRequestTest.php
+++ b/tests/Message/DirectAuthorizeRequestTest.php
@@ -88,7 +88,7 @@ class DirectAuthorizeRequestTest extends TestCase
         // The element does exist, and must contain the basket XML, with optional XML header and
         // trailing newlines.
         $this->assertArrayHasKey('BasketXML', $data);
-        $this->assertContains($basketXml, $data);
+        $this->assertContains($basketXml, $data['BasketXML']);
     }
 
     public function testGetDataNoReferrerId()
@@ -292,7 +292,7 @@ class DirectAuthorizeRequestTest extends TestCase
                     <totalGrossAmount>5</totalGrossAmount>";
 
         $this->request->setItems($items);
-        $data = $this->request->getData(); 
+        $data = $this->request->getData();
 
 
         $this->assertNotContains($expected , $data['BasketXML'], "Should fail as name was not escaped" );

--- a/tests/Message/DirectAuthorizeRequestTest.php
+++ b/tests/Message/DirectAuthorizeRequestTest.php
@@ -182,4 +182,151 @@ class DirectAuthorizeRequestTest extends TestCase
         // converted to an empty string. I'm not clear how that would be
         // tested.
     }
+
+    public function testBasketWithNoDiscount()
+    {
+        $items = new \Omnipay\Common\ItemBag(array(
+            new \Omnipay\Common\Item(array(
+                'name' => 'Name',
+                'description' => 'Description',
+                'quantity' => 1,
+                'price' => 1.23,
+            ))
+        ));
+
+        $this->request->setItems($items);
+        $data = $this->request->getData();
+        // The element does exist, and must contain the basket XML, with optional XML header and
+        // trailing newlines.
+        $this->assertArrayHasKey('BasketXML', $data);
+        $this->assertNotContains('<discount>', $data['BasketXML']);
+    }
+
+    public function testBasketWithOneDiscount()
+    {
+        $items = new \Omnipay\Common\ItemBag(array(
+            new \Omnipay\Common\Item(array(
+                'name' => 'Name',
+                'description' => 'Description',
+                'quantity' => 1,
+                'price' => 10.0,
+            )),
+            array(
+                'name' => 'One Discount',
+                'description' => 'My Offer',
+                'quantity' => 1,
+                'price' => -4,
+            )
+        ));
+
+        $this->request->setItems($items);
+        $data = $this->request->getData();
+        // The element does exist, and must contain the basket XML, with optional XML header and
+        // trailing newlines.
+        $this->assertArrayHasKey('BasketXML', $data);
+        $this->assertContains('<discounts>', $data['BasketXML']);
+    }
+
+    public function testBasketWithTwoDiscount()
+    {
+        $items = new \Omnipay\Common\ItemBag(array(
+            new \Omnipay\Common\Item(array(
+                'name' => 'Name',
+                'description' => 'Description',
+                'quantity' => 1,
+                'price' => 1.23,
+            )),
+            array(
+                'name' => 'One Discount',
+                'description' => 'My Offer',
+                'quantity' => 1,
+                'price' => -4,
+            ),
+            array(
+                'name' => 'Second Discount',
+                'description' => 'My 2nd Offer',
+                'quantity' => 1,
+                'price' => -5,
+            )
+        ));
+
+        $expected = '<basket><item>'
+            . '<description>Name</description><quantity>1</quantity>'
+            . '<unitNetAmount>1.23</unitNetAmount><unitTaxAmount>0.00</unitTaxAmount>'
+            . '<unitGrossAmount>1.23</unitGrossAmount><totalGrossAmount>1.23</totalGrossAmount>'
+            . '</item><discounts><discount><fixed>4</fixed><description>One Discount</description></discount><discount><fixed>5</fixed><description>Second Discount</description></discount></discounts></basket>';
+
+        $this->request->setItems($items);
+        $data = $this->request->getData();
+        // The element does exist, and must contain the basket XML, with optional XML header and
+        // trailing newlines.
+        $this->assertArrayHasKey('BasketXML', $data);
+        $this->assertContains($expected, $data['BasketXML']);
+    }
+
+    public function testBasketWithNotEscapedName()
+    {
+        $items = new \Omnipay\Common\ItemBag(array(
+            new \Omnipay\Common\Item(array(
+                'name' => "Denise's Very Odd & Wierd name?",
+                'description' => 'Description',
+                'quantity' => 1,
+                'price' => 1.23,
+            )),
+            array(
+                'name' => 'One Discount',
+                'description' => 'My Offer',
+                'quantity' => 1,
+                'price' => 4,
+            ),
+            array(
+                'name' => 'Second Discount',
+                'description' => 'My 2nd Offer',
+                'quantity' => 1,
+                'price' => 5,
+            )
+        ));
+
+        $expected = "<basket><item><description>Denise's Very Odd & Wierd name?</description><quantity>1</quantity><unitNetAmount>1.23</unitNetAmount><unitTaxAmount>0.00</unitTaxAmount><unitGrossAmount>1.23</unitGrossAmount><totalGrossAmount>1.23</totalGrossAmount></item><item>
+                    <description>One Discount</description><quantity>1</quantity><unitNetAmount>4</unitNetAmount><unitTaxAmount>0.00</unitTaxAmount><unitGrossAmount>4</unitGrossAmount><totalGrossAmount>4</totalGrossAmount></item><item><description>Second Discount</description><quantity>1</quantity><unitNetAmoubnt>5</unitNetAmoubnt>
+                    <totalGrossAmount>5</totalGrossAmount>";
+
+        $this->request->setItems($items);
+        $data = $this->request->getData();
+
+
+        $this->assertNotContains($expected , $data['BasketXML'], "Should fail as name was not escaped" );
+
+    }
+
+    public function testBasketWithEscapedName()
+    {
+        $items = new \Omnipay\Common\ItemBag(array(
+            new \Omnipay\Common\Item(array(
+                'name' => "Denise's Very Odd & Wierd name?",
+                'description' => 'Description',
+                'quantity' => 1,
+                'price' => 1.23,
+            )),
+            array(
+                'name' => 'One Discount',
+                'description' => 'My Offer',
+                'quantity' => 1,
+                'price' => 4,
+            ),
+            array(
+                'name' => 'Second Discount',
+                'description' => 'My 2nd Offer',
+                'quantity' => 1,
+                'price' => 5,
+            )
+        ));
+
+
+        $this->request->setItems($items);
+        $data = $this->request->getData();
+
+        $this->assertArrayHasKey('BasketXML', $data, "Should create XML");
+        $this->assertContains($data['BasketXML'], $data, "Should not fail as name was escaped" );
+    }
 }

--- a/tests/Message/DirectAuthorizeRequestTest.php
+++ b/tests/Message/DirectAuthorizeRequestTest.php
@@ -88,7 +88,7 @@ class DirectAuthorizeRequestTest extends TestCase
         // The element does exist, and must contain the basket XML, with optional XML header and
         // trailing newlines.
         $this->assertArrayHasKey('BasketXML', $data);
-        $this->assertContains($basketXml, $data['BasketXML']);
+        $this->assertContains($basketXml, $data);
     }
 
     public function testGetDataNoReferrerId()
@@ -292,7 +292,7 @@ class DirectAuthorizeRequestTest extends TestCase
                     <totalGrossAmount>5</totalGrossAmount>";
 
         $this->request->setItems($items);
-        $data = $this->request->getData();
+        $data = $this->request->getData(); 
 
 
         $this->assertNotContains($expected , $data['BasketXML'], "Should fail as name was not escaped" );

--- a/tests/Message/DirectAuthorizeRequestTest.php
+++ b/tests/Message/DirectAuthorizeRequestTest.php
@@ -212,7 +212,7 @@ class DirectAuthorizeRequestTest extends TestCase
     {
         $items = new \Omnipay\Common\ItemBag(array(
             new \Omnipay\Common\Item(array(
-                'name' => "Denisé's Odd & Wierd £name? #",
+                'name' => "Denisé's Odd & Wierd £name? #12345678901234567890123456789012345678901234567890123456789012345678901234567890",
                 'description' => 'Description',
                 'quantity' => 2,
                 'price' => 4.23,
@@ -224,20 +224,22 @@ class DirectAuthorizeRequestTest extends TestCase
                 'price' => -0.10,
             ),
             array(
-                'name' => 'Second Discount',
+                // 101 character name
+                'name' => '12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901',
                 'description' => 'My 2nd Offer',
                 'quantity' => 1,
                 'price' => -1.60,
             )
         ));
 
+        // Names/descriptions should be max 100 characters in length, once invalid characters have been removed.
         $expected = '<basket><item>'
-            . '<description>Denis\'s Odd &amp; Wierd name</description><quantity>2</quantity>'
+            . '<description>Denis\'s Odd &amp; Wierd name 123456789012345678901234567890123456789012345678901234567890123456789012345</description><quantity>2</quantity>'
             . '<unitNetAmount>4.23</unitNetAmount><unitTaxAmount>0.00</unitTaxAmount>'
             . '<unitGrossAmount>4.23</unitGrossAmount><totalGrossAmount>8.46</totalGrossAmount>'
             . '</item><discounts>'
             . '<discount><fixed>0.2</fixed><description>Denis\'s "Odd"  Wierd discount? #</description></discount>'
-            . '<discount><fixed>1.6</fixed><description>Second Discount</description></discount>'
+            . '<discount><fixed>1.6</fixed><description>1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890</description></discount>'
             . '</discounts></basket>';
 
         $this->request->setItems($items);

--- a/tests/Message/DirectAuthorizeRequestTest.php
+++ b/tests/Message/DirectAuthorizeRequestTest.php
@@ -208,131 +208,42 @@ class DirectAuthorizeRequestTest extends TestCase
         $this->assertNotContains('<discount>', $data['BasketXML']);
     }
 
-    public function testBasketWithOneDiscount()
+    public function testMixedBasketWithSpecialChars()
     {
         $items = new \Omnipay\Common\ItemBag(array(
             new \Omnipay\Common\Item(array(
-                'name' => 'Name',
+                'name' => "Denisé's Odd & Wierd £name? #",
                 'description' => 'Description',
-                'quantity' => 1,
-                'price' => 10.0,
+                'quantity' => 2,
+                'price' => 4.23,
             )),
             array(
-                'name' => 'One Discount',
+                'name' => "Denisé's \"Odd\" & Wierd £discount? #",
                 'description' => 'My Offer',
-                'quantity' => 1,
-                'price' => -4,
-            )
-        ));
-
-        $this->request->setItems($items);
-        $data = $this->request->getData();
-        // The element does exist, and must contain the basket XML, with optional XML header and
-        // trailing newlines.
-        $this->assertArrayHasKey('BasketXML', $data);
-        $this->assertContains('<discounts>', $data['BasketXML']);
-    }
-
-    public function testBasketWithTwoDiscount()
-    {
-        $items = new \Omnipay\Common\ItemBag(array(
-            new \Omnipay\Common\Item(array(
-                'name' => 'Name',
-                'description' => 'Description',
-                'quantity' => 1,
-                'price' => 1.23,
-            )),
-            array(
-                'name' => 'One Discount',
-                'description' => 'My Offer',
-                'quantity' => 1,
-                'price' => -4,
+                'quantity' => 2,
+                'price' => -0.10,
             ),
             array(
                 'name' => 'Second Discount',
                 'description' => 'My 2nd Offer',
                 'quantity' => 1,
-                'price' => -5,
+                'price' => -1.60,
             )
         ));
 
         $expected = '<basket><item>'
-            . '<description>Name</description><quantity>1</quantity>'
-            . '<unitNetAmount>1.23</unitNetAmount><unitTaxAmount>0.00</unitTaxAmount>'
-            . '<unitGrossAmount>1.23</unitGrossAmount><totalGrossAmount>1.23</totalGrossAmount>'
-            . '</item><discounts><discount><fixed>4</fixed><description>One Discount</description></discount><discount><fixed>5</fixed><description>Second Discount</description></discount></discounts></basket>';
+            . '<description>Denis\'s Odd &amp; Wierd name</description><quantity>2</quantity>'
+            . '<unitNetAmount>4.23</unitNetAmount><unitTaxAmount>0.00</unitTaxAmount>'
+            . '<unitGrossAmount>4.23</unitGrossAmount><totalGrossAmount>8.46</totalGrossAmount>'
+            . '</item><discounts>'
+            . '<discount><fixed>0.2</fixed><description>Denis\'s "Odd"  Wierd discount? #</description></discount>'
+            . '<discount><fixed>1.6</fixed><description>Second Discount</description></discount>'
+            . '</discounts></basket>';
 
         $this->request->setItems($items);
         $data = $this->request->getData();
-        // The element does exist, and must contain the basket XML, with optional XML header and
-        // trailing newlines.
+
         $this->assertArrayHasKey('BasketXML', $data);
-        $this->assertContains($expected, $data['BasketXML']);
-    }
-
-    public function testBasketWithNotEscapedName()
-    {
-        $items = new \Omnipay\Common\ItemBag(array(
-            new \Omnipay\Common\Item(array(
-                'name' => "Denise's Very Odd & Wierd name?",
-                'description' => 'Description',
-                'quantity' => 1,
-                'price' => 1.23,
-            )),
-            array(
-                'name' => 'One Discount',
-                'description' => 'My Offer',
-                'quantity' => 1,
-                'price' => 4,
-            ),
-            array(
-                'name' => 'Second Discount',
-                'description' => 'My 2nd Offer',
-                'quantity' => 1,
-                'price' => 5,
-            )
-        ));
-
-        $expected = "<basket><item><description>Denise's Very Odd & Wierd name?</description><quantity>1</quantity><unitNetAmount>1.23</unitNetAmount><unitTaxAmount>0.00</unitTaxAmount><unitGrossAmount>1.23</unitGrossAmount><totalGrossAmount>1.23</totalGrossAmount></item><item>
-                    <description>One Discount</description><quantity>1</quantity><unitNetAmount>4</unitNetAmount><unitTaxAmount>0.00</unitTaxAmount><unitGrossAmount>4</unitGrossAmount><totalGrossAmount>4</totalGrossAmount></item><item><description>Second Discount</description><quantity>1</quantity><unitNetAmoubnt>5</unitNetAmoubnt>
-                    <totalGrossAmount>5</totalGrossAmount>";
-
-        $this->request->setItems($items);
-        $data = $this->request->getData();
-
-
-        $this->assertNotContains($expected , $data['BasketXML'], "Should fail as name was not escaped" );
-
-    }
-
-    public function testBasketWithEscapedName()
-    {
-        $items = new \Omnipay\Common\ItemBag(array(
-            new \Omnipay\Common\Item(array(
-                'name' => "<Denise's Very Odd & Wierd 'name'?>",
-                'description' => 'Description',
-                'quantity' => 1,
-                'price' => 1.23,
-            )),
-            array(
-                'name' => 'One Discount',
-                'description' => 'My Offer',
-                'quantity' => 1,
-                'price' => 4,
-            ),
-            array(
-                'name' => 'Second Discount',
-                'description' => 'My 2nd Offer',
-                'quantity' => 1,
-                'price' => 5,
-            )
-        ));
-
-
-        $this->request->setItems($items);
-        $data = $this->request->getData();
-
-        $this->assertArrayHasKey('BasketXML', $data, "Should create XML");
-        $this->assertContains($data['BasketXML'], $data, "Should not fail as name was escaped" );
+        $this->assertContains($expected, $data['BasketXML'], 'Basket XML does not match the expected output');
     }
 }

--- a/tests/Message/DirectAuthorizeRequestTest.php
+++ b/tests/Message/DirectAuthorizeRequestTest.php
@@ -303,7 +303,7 @@ class DirectAuthorizeRequestTest extends TestCase
     {
         $items = new \Omnipay\Common\ItemBag(array(
             new \Omnipay\Common\Item(array(
-                'name' => "Denise's Very Odd & Wierd name?",
+                'name' => "<Denise's Very Odd & Wierd 'name'?>",
                 'description' => 'Description',
                 'quantity' => 1,
                 'price' => 1.23,

--- a/tests/Message/DirectAuthorizeRequestTest.php
+++ b/tests/Message/DirectAuthorizeRequestTest.php
@@ -6,6 +6,11 @@ use Omnipay\Tests\TestCase;
 
 class DirectAuthorizeRequestTest extends TestCase
 {
+    /**
+     * @var \Omnipay\Common\Message\AbstractRequest $request
+     */
+    protected $request;
+
     public function setUp()
     {
         parent::setUp();
@@ -60,6 +65,7 @@ class DirectAuthorizeRequestTest extends TestCase
 
         // Then with a basket containing no items.
         $items = new \Omnipay\Common\ItemBag(array());
+        $this->request->setItems($items);
         $data = $this->request->getData();
         $this->assertArrayNotHasKey('BasketXML', $data);
     }


### PR DESCRIPTION
…haracters in xml basket
we added code to allow zero value items to be included in basket XML and fixed a bug , as add->Child was not escaping html characters (&). Also added tests fro no discount, for one and more discounts, and test for escaped html charaters