### PR TITLE
Issue #33 Default null fields to '' to avoid ambiguity of intent.

### DIFF
--- a/src/Message/ServerCompleteAuthorizeRequest.php
+++ b/src/Message/ServerCompleteAuthorizeRequest.php
@@ -32,20 +32,20 @@ class ServerCompleteAuthorizeRequest extends AbstractRequest
             $reference['VPSTxId'].
             $reference['VendorTxCode'].
             $this->httpRequest->request->get('Status').
-            $this->httpRequest->request->get('TxAuthNo').
+            $this->httpRequest->request->get('TxAuthNo', '').
             $this->getVendor().
-            $this->httpRequest->request->get('AVSCV2').
+            $this->httpRequest->request->get('AVSCV2', '').
             $reference['SecurityKey'].
-            $this->httpRequest->request->get('AddressResult').
-            $this->httpRequest->request->get('PostCodeResult').
-            $this->httpRequest->request->get('CV2Result').
-            $this->httpRequest->request->get('GiftAid').
-            $this->httpRequest->request->get('3DSecureStatus').
-            $this->httpRequest->request->get('CAVV').
+            $this->httpRequest->request->get('AddressResult', '').
+            $this->httpRequest->request->get('PostCodeResult', '').
+            $this->httpRequest->request->get('CV2Result', '').
+            $this->httpRequest->request->get('GiftAid', '').
+            $this->httpRequest->request->get('3DSecureStatus', '').
+            $this->httpRequest->request->get('CAVV', '').
             $this->httpRequest->request->get('AddressStatus').
-            $this->httpRequest->request->get('PayerStatus').
-            $this->httpRequest->request->get('CardType').
-            $this->httpRequest->request->get('Last4Digits').
+            $this->httpRequest->request->get('PayerStatus', '').
+            $this->httpRequest->request->get('CardType', '').
+            $this->httpRequest->request->get('Last4Digits', '').
             // New for protocol v3.00
             // Described in the docs as "mandatory" but not supplied when PayPal is used,
             // so provide the defaults.


### PR DESCRIPTION
No functional change - should work exactly as before. This just avoids concatenating nulls to strings, which was just a little ambiguous.