### PR TITLE
Add repeat payment support to DirectAuthorize and DirectPurchase.

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -27,6 +27,17 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return $this->action;
     }
 
+    /**
+     * The TxType is usually the same as the service, but not always.
+     *
+     * @return string
+     * @author Dom Morgan <dom@d3r.com>
+     */
+    public function getTxType()
+    {
+        return $this->action;
+    }
+
     public function getAccountType()
     {
         return $this->getParameter('accountType');
@@ -34,9 +45,9 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
 
     /**
      * Set account type.
-     * 
+     *
      * This is ignored for all PAYPAL transactions.
-     * 
+     *
      * @param string $value E: Use the e-commerce merchant account. (default)
      *                      M: Use the mail/telephone order account. (if present)
      *                      C: Use the continuous authority merchant account. (if present)
@@ -66,7 +77,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
 
     /**
      * Set the apply AVSCV2 checks.
-     * 
+     *
      * @param  int $value 0: If AVS/CV2 enabled then check them. If rules apply, use rules. (default)
      *                    1: Force AVS/CV2 checks even if not enabled for the account. If rules apply
      *                       use rules.
@@ -86,9 +97,9 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
 
     /**
      * Whether or not to apply 3D secure authentication.
-     * 
+     *
      * This is ignored for PAYPAL, EUROPEAN PAYMENT transactions.
-     * 
+     *
      * @param  int $value 0: If 3D-Secure checks are possible and rules allow, perform the
      *                       checks and apply the authorisation rules. (default)
      *                    1: Force 3D-Secure checks for this transaction if possible and
@@ -107,7 +118,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     {
         $data = array();
         $data['VPSProtocol'] = '3.00';
-        $data['TxType'] = $this->action;
+        $data['TxType'] = $this->getTxType();
         $data['Vendor'] = $this->getVendor();
         $data['AccountType'] = $this->getAccountType() ?: 'E';
 

--- a/src/Message/DirectAuthorizeRequest.php
+++ b/src/Message/DirectAuthorizeRequest.php
@@ -24,8 +24,6 @@ class DirectAuthorizeRequest extends AbstractRequest
         $data['Currency'] = $this->getCurrency();
         $data['VendorTxCode'] = $this->getTransactionId();
         $data['ClientIPAddress'] = $this->getClientIp();
-        $data['ApplyAVSCV2'] = $this->getApplyAVSCV2() ?: 0;
-        $data['Apply3DSecure'] = $this->getApply3DSecure() ?: 0;
 
         if ($this->getReferrerId()) {
             $data['ReferrerID'] = $this->getReferrerId();
@@ -65,28 +63,62 @@ class DirectAuthorizeRequest extends AbstractRequest
     public function getData()
     {
         $data = $this->getBaseAuthorizeData();
-        $this->getCard()->validate();
 
-        $data['CardHolder'] = $this->getCard()->getName();
-        $data['CardNumber'] = $this->getCard()->getNumber();
-        $data['CV2'] = $this->getCard()->getCvv();
-        $data['ExpiryDate'] = $this->getCard()->getExpiryDate('my');
-        $data['CardType'] = $this->getCardBrand();
+        if ($this->getTransactionReference()) {
+            $this->validate('amount', 'transactionReference');
+            $reference = json_decode($this->getTransactionReference(), true);
+            $data['RelatedVendorTxCode'] = $reference['VendorTxCode'];
+            $data['RelatedVPSTxId'] = $reference['VPSTxId'];
+            $data['RelatedSecurityKey'] = $reference['SecurityKey'];
+            $data['RelatedTxAuthNo'] = $reference['TxAuthNo'];
+        } else {
+            $this->getCard()->validate();
+            $data['Apply3DSecure'] = $this->getApply3DSecure() ?: 0;
+            $data['ApplyAVSCV2'] = $this->getApplyAVSCV2() ?: 0;
+            $data['CardHolder'] = $this->getCard()->getName();
+            $data['CardNumber'] = $this->getCard()->getNumber();
+            $data['CV2'] = $this->getCard()->getCvv();
+            $data['ExpiryDate'] = $this->getCard()->getExpiryDate('my');
+            $data['CardType'] = $this->getCardBrand();
 
-        if ($this->getCard()->getStartMonth() and $this->getCard()->getStartYear()) {
-            $data['StartDate'] = $this->getCard()->getStartDate('my');
-        }
+            if ($this->getCard()->getStartMonth() and $this->getCard()->getStartYear()) {
+                $data['StartDate'] = $this->getCard()->getStartDate('my');
+            }
 
-        if ($this->getCard()->getIssueNumber()) {
-            $data['IssueNumber'] = $this->getCard()->getIssueNumber();
+            if ($this->getCard()->getIssueNumber()) {
+                $data['IssueNumber'] = $this->getCard()->getIssueNumber();
+            }
         }
 
         return $data;
     }
 
+    /**
+     * If we are making a repeat transaction, we need the repeat endpoint
+     *
+     * @return string
+     * @author Dom Morgan <dom@d3r.com>
+     */
     public function getService()
     {
+        if ($this->isRepeat()) {
+            return 'repeat';
+        }
         return 'vspdirect-register';
+    }
+
+    /**
+     * We need to send a different type when we repeat a payment
+     *
+     * @return string
+     * @author Dom Morgan <dom@d3r.com>
+     */
+    public function getTxType()
+    {
+        if ($this->isRepeat()) {
+            return 'REPEAT' . $this->action;
+        }
+        return $this->action;
     }
 
     protected function getCardBrand()
@@ -98,5 +130,16 @@ class DirectAuthorizeRequest extends AbstractRequest
         }
 
         return $brand;
+    }
+
+    /**
+     * Is this a repeat transaction?
+     *
+     * @return boolean
+     * @author Dom Morgan <dom@d3r.com>
+     */
+    protected function isRepeat()
+    {
+        return false !== $this->getTransactionReference();
     }
 }

--- a/src/Message/DirectAuthorizeRequest.php
+++ b/src/Message/DirectAuthorizeRequest.php
@@ -64,7 +64,7 @@ class DirectAuthorizeRequest extends AbstractRequest
     {
         $data = $this->getBaseAuthorizeData();
 
-        if ($this->getTransactionReference()) {
+        if ($this->isRepeat()) {
             $this->validate('amount', 'transactionReference');
             $reference = json_decode($this->getTransactionReference(), true);
             $data['RelatedVendorTxCode'] = $reference['VendorTxCode'];
@@ -140,6 +140,6 @@ class DirectAuthorizeRequest extends AbstractRequest
      */
     protected function isRepeat()
     {
-        return false !== $this->getTransactionReference();
+        return !empty($this->getTransactionReference());
     }
 }

--- a/src/Message/DirectAuthorizeRequest.php
+++ b/src/Message/DirectAuthorizeRequest.php
@@ -65,7 +65,6 @@ class DirectAuthorizeRequest extends AbstractRequest
         $data = $this->getBaseAuthorizeData();
 
         if ($this->isRepeat()) {
-            $this->validate('amount', 'transactionReference');
             $reference = json_decode($this->getTransactionReference(), true);
             $data['RelatedVendorTxCode'] = $reference['VendorTxCode'];
             $data['RelatedVPSTxId'] = $reference['VPSTxId'];

--- a/src/Message/DirectAuthorizeRequest.php
+++ b/src/Message/DirectAuthorizeRequest.php
@@ -139,6 +139,6 @@ class DirectAuthorizeRequest extends AbstractRequest
      */
     protected function isRepeat()
     {
-        return !empty($this->getTransactionReference());
+        return false != $this->getTransactionReference();
     }
 }

--- a/src/Message/DirectPurchaseRequest.php
+++ b/src/Message/DirectPurchaseRequest.php
@@ -8,4 +8,18 @@ namespace Omnipay\SagePay\Message;
 class DirectPurchaseRequest extends DirectAuthorizeRequest
 {
     protected $action = 'PAYMENT';
+
+    /**
+     * A repeat payment is just REPEAT, not REPEATPAYMENT.
+     *
+     * @return string
+     * @author Dom Morgan <dom@d3r.com>
+     */
+    public function getTxType()
+    {
+        if ($this->isRepeat()) {
+            return 'REPEAT';
+        }
+        return $this->action;
+    }
 }

--- a/tests/DirectGatewayTest.php
+++ b/tests/DirectGatewayTest.php
@@ -24,6 +24,13 @@ class DirectGatewayTest extends GatewayTestCase
             'transactionId' => '123',
             'transactionReference' => '{"SecurityKey":"JEUPDN1N7E","TxAuthNo":"4255","VPSTxId":"{F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2}","VendorTxCode":"438791"}',
         );
+
+        $this->repeatOptions = array(
+            'amount' => '10.00',
+            'transactionId' => '123',
+            'card' => $this->getAddressOnlyCard(),
+            'transactionReference' => '{"SecurityKey":"JEUPDN1N7E","TxAuthNo":"4255","VPSTxId":"{F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2}","VendorTxCode":"438791"}',
+        );
     }
 
     public function testAuthorizeFailureSuccess()
@@ -68,6 +75,18 @@ class DirectGatewayTest extends GatewayTestCase
         $this->assertSame('https://www.example.com/return', $redirectData['TermUrl']);
     }
 
+    public function testAuthorizeRepeat()
+    {
+        $this->setMockHttpResponse('DirectPurchaseSuccess.txt');
+
+        $response = $this->gateway->authorize($this->repeatOptions)->send();
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertSame('{"SecurityKey":"OUWLNYQTVT","TxAuthNo":"9962","VPSTxId":"{5A1BC414-5409-48DD-9B8B-DCDF096CE0BE}","VendorTxCode":"123"}', $response->getTransactionReference());
+        $this->assertSame('Direct transaction from Simulator.', $response->getMessage());
+    }
+
     public function testPurchaseSuccess()
     {
         $this->setMockHttpResponse('DirectPurchaseSuccess.txt');
@@ -108,6 +127,18 @@ class DirectGatewayTest extends GatewayTestCase
         $this->assertSame('065379457749061954', $redirectData['MD']);
         $this->assertSame('BSkaFwYFFTYAGyFbAB0LFRYWBwsBZw0EGwECEX9YRGFWc08pJCVVKgAANS0KADoZCCAMBnIeOxcWRg0LERdOOTQRDFRdVHNYUgwTMBsBCxABJw4DJHE+ERgPCi8MVC0HIAROCAAfBUk4ER89DD0IWDkvMQ1VdFwoUFgwXVYvbHgvMkdBXXNbQGIjdl1ZUEc1XSwqAAgUUicYBDYcB3I2AjYjIzsn', $redirectData['PaReq']);
         $this->assertSame('https://www.example.com/return', $redirectData['TermUrl']);
+    }
+
+    public function testPurchaseRepeat()
+    {
+        $this->setMockHttpResponse('DirectPurchaseSuccess.txt');
+
+        $response = $this->gateway->authorize($this->repeatOptions)->send();
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertSame('{"SecurityKey":"OUWLNYQTVT","TxAuthNo":"9962","VPSTxId":"{5A1BC414-5409-48DD-9B8B-DCDF096CE0BE}","VendorTxCode":"123"}', $response->getTransactionReference());
+        $this->assertSame('Direct transaction from Simulator.', $response->getMessage());
     }
 
     public function testCaptureSuccess()
@@ -152,5 +183,25 @@ class DirectGatewayTest extends GatewayTestCase
         $this->assertFalse($response->isSuccessful());
         $this->assertSame('{"VendorTxCode":"123"}', $response->getTransactionReference());
         $this->assertSame('You are trying to RELEASE a transaction that has already been RELEASEd or ABORTed.', $response->getMessage());
+    }
+
+    public function getAddressOnlyCard()
+    {
+        return array(
+            'billingAddress1' => '123 Billing St',
+            'billingAddress2' => 'Billsville',
+            'billingCity' => 'Billstown',
+            'billingPostcode' => '12345',
+            'billingState' => 'CA',
+            'billingCountry' => 'US',
+            'billingPhone' => '(555) 123-4567',
+            'shippingAddress1' => '123 Shipping St',
+            'shippingAddress2' => 'Shipsville',
+            'shippingCity' => 'Shipstown',
+            'shippingPostcode' => '54321',
+            'shippingState' => 'NY',
+            'shippingCountry' => 'US',
+            'shippingPhone' => '(555) 987-6543',
+        );
     }
 }

--- a/tests/Message/DirectAuthorizeRequestRepeatTest.php
+++ b/tests/Message/DirectAuthorizeRequestRepeatTest.php
@@ -40,12 +40,10 @@ class DirectAuthorizeRequestRepeatTest extends TestCase
         $this->assertSame('4255', $data['RelatedTxAuthNo']);
     }
 
-    /**
-     * Make sure we are hitting the repeat specific endpoint
-     */
     public function testGetEndpoint()
     {
         $url = $this->request->getEndpoint();
+
         $this->assertSame('https://live.sagepay.com/gateway/service/repeat.vsp', $url);
     }
 }

--- a/tests/Message/DirectAuthorizeRequestRepeatTest.php
+++ b/tests/Message/DirectAuthorizeRequestRepeatTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Omnipay\SagePay\Message;
+
+use Omnipay\Tests\TestCase;
+
+class DirectAuthorizeRequestRepeatTest extends TestCase
+{
+    /**
+     * @var \Omnipay\Common\Message\AbstractRequest $request
+     */
+    protected $request;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->request = new DirectAuthorizeRequest($this->getHttpClient(), $this->getHttpRequest());
+        $this->request->initialize(
+            array(
+                'amount' => '12.00',
+                'currency' => 'GBP',
+                'transactionId' => '123',
+                'card' => $this->getValidCard(),
+                'amount' => '12.00',
+                'transactionReference' => '{"SecurityKey":"JEUPDN1N7E","TxAuthNo":"4255","VPSTxId":"{F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2}","VendorTxCode":"438791"}',
+                'testMode' => true,
+            )
+        );
+    }
+
+    public function testGetData()
+    {
+        $data = $this->request->getData();
+
+        $this->assertSame('REPEATDEFERRED', $data['TxType']);
+        $this->assertSame('12.00', $data['Amount']);
+        $this->assertSame('438791', $data['RelatedVendorTxCode']);
+        $this->assertSame('{F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2}', $data['RelatedVPSTxId']);
+        $this->assertSame('JEUPDN1N7E', $data['RelatedSecurityKey']);
+        $this->assertSame('4255', $data['RelatedTxAuthNo']);
+    }
+
+    public function testGetEndpoint()
+    {
+        $url = $this->request->getEndpoint();
+
+        $this->assertSame('https://test.sagepay.com/gateway/service/repeat.vsp', $url);
+    }
+}

--- a/tests/Message/DirectAuthorizeRequestRepeatTest.php
+++ b/tests/Message/DirectAuthorizeRequestRepeatTest.php
@@ -24,7 +24,6 @@ class DirectAuthorizeRequestRepeatTest extends TestCase
                 'card' => $this->getValidCard(),
                 'amount' => '12.00',
                 'transactionReference' => '{"SecurityKey":"JEUPDN1N7E","TxAuthNo":"4255","VPSTxId":"{F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2}","VendorTxCode":"438791"}',
-                'testMode' => true,
             )
         );
     }
@@ -41,10 +40,12 @@ class DirectAuthorizeRequestRepeatTest extends TestCase
         $this->assertSame('4255', $data['RelatedTxAuthNo']);
     }
 
+    /**
+     * Make sure we are hitting the repeat specific endpoint
+     */
     public function testGetEndpoint()
     {
         $url = $this->request->getEndpoint();
-
-        $this->assertSame('https://test.sagepay.com/gateway/service/repeat.vsp', $url);
+        $this->assertSame('https://live.sagepay.com/gateway/service/repeat.vsp', $url);
     }
 }

--- a/tests/Message/DirectAuthorizeRequestTest.php
+++ b/tests/Message/DirectAuthorizeRequestTest.php
@@ -248,4 +248,13 @@ class DirectAuthorizeRequestTest extends TestCase
         $this->assertArrayHasKey('BasketXML', $data);
         $this->assertContains($expected, $data['BasketXML'], 'Basket XML does not match the expected output');
     }
+
+    /**
+     * Make sure we are hitting the repeat specific endpoint
+     */
+    public function testGetEndpoint()
+    {
+        $url = $this->request->getEndpoint();
+        $this->assertSame('https://live.sagepay.com/gateway/service/vspdirect-register.vsp', $url);
+    }
 }

--- a/tests/Message/DirectAuthorizeRequestTest.php
+++ b/tests/Message/DirectAuthorizeRequestTest.php
@@ -249,12 +249,10 @@ class DirectAuthorizeRequestTest extends TestCase
         $this->assertContains($expected, $data['BasketXML'], 'Basket XML does not match the expected output');
     }
 
-    /**
-     * Make sure we are hitting the repeat specific endpoint
-     */
     public function testGetEndpoint()
     {
         $url = $this->request->getEndpoint();
+
         $this->assertSame('https://live.sagepay.com/gateway/service/vspdirect-register.vsp', $url);
     }
 }

--- a/tests/Message/DirectPurchaseRequestRepeatTest.php
+++ b/tests/Message/DirectPurchaseRequestRepeatTest.php
@@ -24,7 +24,6 @@ class DirectPurchaseRequestRepeatTest extends TestCase
                 'card' => $this->getValidCard(),
                 'amount' => '12.00',
                 'transactionReference' => '{"SecurityKey":"JEUPDN1N7E","TxAuthNo":"4255","VPSTxId":"{F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2}","VendorTxCode":"438791"}',
-                'testMode' => true,
             )
         );
     }
@@ -39,5 +38,14 @@ class DirectPurchaseRequestRepeatTest extends TestCase
         $this->assertSame('{F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2}', $data['RelatedVPSTxId']);
         $this->assertSame('JEUPDN1N7E', $data['RelatedSecurityKey']);
         $this->assertSame('4255', $data['RelatedTxAuthNo']);
+    }
+
+    /**
+     * Make sure we are hitting the repeat specific endpoint
+     */
+    public function testGetEndpoint()
+    {
+        $url = $this->request->getEndpoint();
+        $this->assertSame('https://live.sagepay.com/gateway/service/repeat.vsp', $url);
     }
 }

--- a/tests/Message/DirectPurchaseRequestRepeatTest.php
+++ b/tests/Message/DirectPurchaseRequestRepeatTest.php
@@ -40,12 +40,10 @@ class DirectPurchaseRequestRepeatTest extends TestCase
         $this->assertSame('4255', $data['RelatedTxAuthNo']);
     }
 
-    /**
-     * Make sure we are hitting the repeat specific endpoint
-     */
     public function testGetEndpoint()
     {
         $url = $this->request->getEndpoint();
+
         $this->assertSame('https://live.sagepay.com/gateway/service/repeat.vsp', $url);
     }
 }

--- a/tests/Message/DirectPurchaseRequestRepeatTest.php
+++ b/tests/Message/DirectPurchaseRequestRepeatTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Omnipay\SagePay\Message;
+
+use Omnipay\Tests\TestCase;
+
+class DirectPurchaseRequestRepeatTest extends TestCase
+{
+    /**
+     * @var \Omnipay\Common\Message\AbstractRequest $request
+     */
+    protected $request;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->request = new DirectPurchaseRequest($this->getHttpClient(), $this->getHttpRequest());
+        $this->request->initialize(
+            array(
+                'amount' => '12.00',
+                'currency' => 'GBP',
+                'transactionId' => '123',
+                'card' => $this->getValidCard(),
+                'amount' => '12.00',
+                'transactionReference' => '{"SecurityKey":"JEUPDN1N7E","TxAuthNo":"4255","VPSTxId":"{F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2}","VendorTxCode":"438791"}',
+                'testMode' => true,
+            )
+        );
+    }
+
+    public function testGetData()
+    {
+        $data = $this->request->getData();
+
+        $this->assertSame('REPEAT', $data['TxType']);
+        $this->assertSame('12.00', $data['Amount']);
+        $this->assertSame('438791', $data['RelatedVendorTxCode']);
+        $this->assertSame('{F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2}', $data['RelatedVPSTxId']);
+        $this->assertSame('JEUPDN1N7E', $data['RelatedSecurityKey']);
+        $this->assertSame('4255', $data['RelatedTxAuthNo']);
+    }
+}


### PR DESCRIPTION
Fixes #58.

Use is via the `transactionReference` parameter as in the RefundRequest. As there, this is a JSON string something like:
`{"SecurityKey":"JEUPDN1N7E","TxAuthNo":"4255","VPSTxId":"{F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2}","VendorTxCode":"438791"}`

The card parameter is still required to pass customer data but is not validated.

I have also added some tests to make sure the endpoint and TxType changes function as they should.
