### PR TITLE
Fixes #61 Support for SagePay token system

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -34,9 +34,9 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
 
     /**
      * Set account type.
-     * 
+     *
      * This is ignored for all PAYPAL transactions.
-     * 
+     *
      * @param string $value E: Use the e-commerce merchant account. (default)
      *                      M: Use the mail/telephone order account. (if present)
      *                      C: Use the continuous authority merchant account. (if present)
@@ -66,7 +66,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
 
     /**
      * Set the apply AVSCV2 checks.
-     * 
+     *
      * @param  int $value 0: If AVS/CV2 enabled then check them. If rules apply, use rules. (default)
      *                    1: Force AVS/CV2 checks even if not enabled for the account. If rules apply
      *                       use rules.
@@ -86,9 +86,9 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
 
     /**
      * Whether or not to apply 3D secure authentication.
-     * 
+     *
      * This is ignored for PAYPAL, EUROPEAN PAYMENT transactions.
-     * 
+     *
      * @param  int $value 0: If 3D-Secure checks are possible and rules allow, perform the
      *                       checks and apply the authorisation rules. (default)
      *                    1: Force 3D-Secure checks for this transaction if possible and
@@ -137,6 +137,46 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         }
 
         return $this->liveEndpoint."/$service.vsp";
+    }
+
+    /**
+     * Use this flag to indicate you wish to have a token generated and stored in the SagePay database and
+     * returned to you for future use.
+     *
+     * @param bool|int $createToken 0 = This will not create a token from the payment (default).
+     *                              1 = This will create a token from the payment if
+     *                                  successful and return a Token.
+     */
+    public function setCreateToken($createToken)
+    {
+        $createToken = (bool)$createToken;
+
+        $this->setParameter('createToken', (int)$createToken);
+    }
+
+    public function getCreateToken()
+    {
+        return $this->parameters->get('createToken', 0);
+    }
+
+    /**
+     * An optional flag to indicate if you wish to continue to store the Token in the SagePay
+     * token database for future use.
+     *
+     * @param bool|int $storeToken  0 = The Token will be deleted from the SagePay database if
+     *                                  authorised by the bank (default).
+     *                              1 = Continue to store the Token in the SagePay database for future use.
+     */
+    public function setStoreToken($storeToken)
+    {
+        $storeToken = (bool)$storeToken;
+
+        $this->setParameter('storeToken', (int)$storeToken);
+    }
+
+    public function getStoreToken()
+    {
+        return $this->parameters->get('storeToken', 0);
     }
 
     protected function createResponse($data)

--- a/src/Message/DirectAuthorizeRequest.php
+++ b/src/Message/DirectAuthorizeRequest.php
@@ -26,7 +26,15 @@ class DirectAuthorizeRequest extends AbstractRequest
         $data['ClientIPAddress'] = $this->getClientIp();
         $data['ApplyAVSCV2'] = $this->getApplyAVSCV2() ?: 0;
         $data['Apply3DSecure'] = $this->getApply3DSecure() ?: 0;
+        $data['CreateToken'] = $this->getCreateToken();
 
+        // Creating a token should not be permissible at
+        // the same time as using a token.
+        if (!$data['CreateToken'] && $this->getToken()) {
+            $data['Token'] = $this->getToken();
+            $data['StoreToken'] = $this->getStoreToken();
+        }
+        
         if ($this->getReferrerId()) {
             $data['ReferrerID'] = $this->getReferrerId();
         }
@@ -68,7 +76,12 @@ class DirectAuthorizeRequest extends AbstractRequest
         $this->getCard()->validate();
 
         $data['CardHolder'] = $this->getCard()->getName();
-        $data['CardNumber'] = $this->getCard()->getNumber();
+
+        // Card number should not be provided if token is being provided instead
+        if (!$this->getToken()) {
+            $data['CardNumber'] = $this->getCard()->getNumber();
+        }
+
         $data['CV2'] = $this->getCard()->getCvv();
         $data['ExpiryDate'] = $this->getCard()->getExpiryDate('my');
         $data['CardType'] = $this->getCardBrand();

--- a/src/Message/DirectTokenRegistrationRequest.php
+++ b/src/Message/DirectTokenRegistrationRequest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Omnipay\SagePay\Message;
+
+class DirectTokenRegistrationRequest extends AbstractRequest
+{
+    protected $action = 'TOKEN';
+    protected $cardBrandMap = array(
+        'mastercard' => 'mc',
+        'diners_club' => 'dc'
+    );
+
+    public function getData()
+    {
+        $this->validate('card');
+
+        $data = $this->getBaseData();
+
+        $data['VendorTxCode'] = $this->getTransactionId();
+        $data['Currency'] = $this->getCurrency();
+        $data['CardHolder'] = $this->getCard()->getBillingName();
+        $data['CardNumber'] = $this->getCard()->getNumber();
+        $data['ExpiryDate'] = $this->getCard()->getExpiryDate('my');
+        $data['CV2'] = $this->getCard()->getCvv();
+        $data['CardType'] = $this->getCardBrand();
+
+        unset($data['AccountType']);
+
+        return $data;
+    }
+
+    public function getService()
+    {
+        return 'directtoken';
+    }
+
+    protected function getCardBrand()
+    {
+        $brand = $this->getCard()->getBrand();
+
+        if (isset($this->cardBrandMap[$brand])) {
+            return $this->cardBrandMap[$brand];
+        }
+
+        return $brand;
+    }
+}

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -87,6 +87,11 @@ class Response extends AbstractResponse implements RedirectResponseInterface
         }
     }
 
+    public function getToken()
+    {
+        return isset($this->data['Token']) ? $this->data['Token'] : null;
+    }
+
     /**
      * Decode raw ini-style response body
      *

--- a/src/Message/ServerTokenRegistrationCompleteRequest.php
+++ b/src/Message/ServerTokenRegistrationCompleteRequest.php
@@ -14,7 +14,7 @@ class ServerTokenRegistrationCompleteRequest extends AbstractRequest
 
         // Strip out leading/trailing curly brackets as these are not required in the
         // MD5 signature for some reason (unlike in the standard Server request).
-        $vpsTxId = str_replace(['{', '}'], '', $reference['VPSTxId']);
+        $vpsTxId = str_replace(array('{', '}'), '', $reference['VPSTxId']);
 
         // Re-create the VPSSignature
         $signature_string =

--- a/src/Message/ServerTokenRegistrationCompleteRequest.php
+++ b/src/Message/ServerTokenRegistrationCompleteRequest.php
@@ -34,7 +34,7 @@ class ServerTokenRegistrationCompleteRequest extends AbstractRequest
     public function getData()
     {
         $signature = $this->getSignature();
-
+        
         if (strtolower($this->httpRequest->request->get('VPSSignature')) !== $signature) {
             throw new InvalidResponseException();
         }

--- a/src/Message/ServerTokenRegistrationCompleteRequest.php
+++ b/src/Message/ServerTokenRegistrationCompleteRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Omnipay\SagePay\Message;
+
+use Omnipay\Common\Exception\InvalidResponseException;
+
+class ServerTokenRegistrationCompleteRequest extends AbstractRequest
+{
+    public function getSignature()
+    {
+        $this->validate('transactionReference');
+
+        $reference = json_decode($this->getTransactionReference(), true);
+
+        // Strip out leading/trailing curly brackets as these are not required in the
+        // MD5 signature for some reason (unlike in the standard Server request).
+        $vpsTxId = str_replace(['{', '}'], '', $reference['VPSTxId']);
+
+        // Re-create the VPSSignature
+        $signature_string =
+            $vpsTxId.
+            $reference['VendorTxCode'].
+            $this->httpRequest->request->get('Status').
+            $this->getVendor().
+            $this->httpRequest->request->get('Token').
+            $reference['SecurityKey'];
+
+        return md5($signature_string);
+    }
+
+    /**
+     * Get the POSTed data, checking that the signature is valid.
+     */
+    public function getData()
+    {
+        $signature = $this->getSignature();
+
+        if (strtolower($this->httpRequest->request->get('VPSSignature')) !== $signature) {
+            throw new InvalidResponseException();
+        }
+
+        return $this->httpRequest->request->all();
+    }
+
+    public function sendData($data)
+    {
+        return $this->response = new ServerTokenRegistrationCompleteResponse($this, $data);
+    }
+}

--- a/src/Message/ServerTokenRegistrationCompleteResponse.php
+++ b/src/Message/ServerTokenRegistrationCompleteResponse.php
@@ -6,9 +6,6 @@ class ServerTokenRegistrationCompleteResponse extends ServerCompleteAuthorizeRes
 {
     public function getTransactionReference()
     {
-        $reference = json_decode($this->getRequest()->getTransactionReference(), true);
-        $reference['VendorTxCode'] = $this->getRequest()->getTransactionId();
-
-        return json_encode($reference);
+        return $this->request->getTransactionReference();
     }
 }

--- a/src/Message/ServerTokenRegistrationCompleteResponse.php
+++ b/src/Message/ServerTokenRegistrationCompleteResponse.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Omnipay\SagePay\Message;
+
+class ServerTokenRegistrationCompleteResponse extends ServerCompleteAuthorizeResponse
+{
+    public function getTransactionReference()
+    {
+        $reference = json_decode($this->getRequest()->getTransactionReference(), true);
+        $reference['VendorTxCode'] = $this->getRequest()->getTransactionId();
+
+        return json_encode($reference);
+    }
+}

--- a/src/Message/ServerTokenRegistrationRequest.php
+++ b/src/Message/ServerTokenRegistrationRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Omnipay\SagePay\Message;
+
+class ServerTokenRegistrationRequest extends AbstractRequest
+{
+    protected $action = 'TOKEN';
+
+    /**
+     * @return mixed
+     */
+    public function getData()
+    {
+        $data = $this->getBaseData();
+        $data['Currency'] = $this->getCurrency();
+        $data['NotificationURL'] = $this->getReturnUrl();
+        $data['VendorTxCode'] = $this->getTransactionId();
+
+        unset($data['AccountType']);
+
+        return $data;
+    }
+
+    /**
+     * @param mixed $data
+     * @return ServerTokenRegistrationResponse
+     */
+    public function createResponse($data)
+    {
+        return $this->response = new ServerTokenRegistrationResponse($this, $data);
+    }
+}

--- a/src/Message/ServerTokenRegistrationResponse.php
+++ b/src/Message/ServerTokenRegistrationResponse.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Omnipay\SagePay\Message;
+
+class ServerTokenRegistrationResponse extends Response
+{
+    public function isSuccessful()
+    {
+        return false;
+    }
+
+    public function isRedirect()
+    {
+        return isset($this->data['Status']) &&
+        in_array($this->data['Status'], array('OK', 'OK REPEATED'));
+    }
+
+    public function getRedirectUrl()
+    {
+        return isset($this->data['NextURL']) ? $this->data['NextURL'] : null;
+    }
+
+    public function getRedirectMethod()
+    {
+        return 'GET';
+    }
+
+    public function getRedirectData()
+    {
+        return null;
+    }
+}

--- a/src/Message/TokenRemovalRequest.php
+++ b/src/Message/TokenRemovalRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Omnipay\SagePay\Message;
+
+class TokenRemovalRequest extends AbstractRequest
+{
+    protected $action = 'REMOVETOKEN';
+
+    /**
+     * @return mixed
+     */
+    public function getData()
+    {
+        $data = $this->getBaseData();
+        $data['Token'] = $this->getToken();
+
+        unset($data['AccountType']);
+
+        return $data;
+    }
+
+    public function getService()
+    {
+        return 'removetoken';
+    }
+}

--- a/src/ServerGateway.php
+++ b/src/ServerGateway.php
@@ -35,4 +35,14 @@ class ServerGateway extends DirectGateway
     {
         return $this->completeAuthorize($parameters);
     }
+
+    public function registerToken(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\SagePay\Message\ServerTokenRegistrationRequest', $parameters);
+    }
+
+    public function completeRegistration(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\SagePay\Message\ServerTokenRegistrationCompleteRequest', $parameters);
+    }
 }

--- a/tests/Message/DirectTokenRequestTest.php
+++ b/tests/Message/DirectTokenRequestTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Omnipay\SagePay\Message;
+
+use Omnipay\Tests\TestCase;
+
+class DirectTokenRequestTest extends TestCase
+{
+    /**
+     * @var \Omnipay\Common\Message\AbstractRequest $request
+     */
+    protected $request;
+    /**
+     * @var array
+     */
+    protected $card;
+
+    public function setUp()
+    {
+        $this->request = new DirectTokenRegistrationRequest($this->getHttpClient(), $this->getHttpRequest());
+        $this->request->initialize(
+            array(
+                'amount' => '12.00',
+                'currency' => 'GBP',
+                'transactionId' => '123',
+                'card' => $this->getValidCard(),
+            )
+        );
+    }
+
+    public function testGetData()
+    {
+        $data = $this->request->getData();
+
+        $this->assertSame('3.00', $data['VPSProtocol']);
+        $this->assertSame('GBP', $data['Currency']);
+        $this->assertSame('123', $data['VendorTxCode']);
+        $this->assertSame('TOKEN', $data['TxType']);
+        $this->assertSame('visa', $data['CardType']);
+        $this->assertArrayNotHasKey('AccountType', $data);
+
+        $card = $this->request->getCard();
+
+        $this->assertSame($card->getNumber(), $data['CardNumber']);
+        $this->assertSame($card->getCvv(), $data['CV2']);
+        $this->assertSame($card->getName(), $data['CardHolder']);
+        $this->assertSame($card->getExpiryDate('my'), $data['ExpiryDate']);
+    }
+
+    public function testGetDataMastercard()
+    {
+        $this->request->getCard()->setNumber('5404000000000001');
+        $data = $this->request->getData();
+
+        $this->assertSame('mc', $data['CardType']);
+    }
+
+    public function testGetDataDinersClub()
+    {
+        $this->request->getCard()->setNumber('30569309025904');
+        $data = $this->request->getData();
+
+        $this->assertSame('dc', $data['CardType']);
+    }
+
+}

--- a/tests/Message/ResponseTest.php
+++ b/tests/Message/ResponseTest.php
@@ -71,4 +71,13 @@ class ResponseTest extends TestCase
         $this->assertSame('{"VendorTxCode":"123456"}', $response->getTransactionReference());
         $this->assertSame('You are trying to RELEASE a transaction that has already been RELEASEd or ABORTed.', $response->getMessage());
     }
+
+    public function testDirectPurchaseWithToken()
+    {
+        $httpResponse = $this->getMockHttpResponse('DirectPurchaseWithToken.txt');
+        $response = new Response($this->getMockRequest(), $httpResponse->getBody());
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertSame('{ABCDEFGH-ABCD-ABCD-ABCD-ABCDEFGHIJKL}', $response->getToken());
+    }
 }

--- a/tests/Message/ServerAuthorizeResponseTest.php
+++ b/tests/Message/ServerAuthorizeResponseTest.php
@@ -25,7 +25,6 @@ class ServerAuthorizeResponseTest extends TestCase
         $this->assertNull($response->getRedirectData());
     }
 
-
     public function testServerPurchaseRepeated()
     {
         $response = new ServerAuthorizeResponse($this->getMockRequest(), 'Status=OK REPEATED');

--- a/tests/Message/ServerAuthorizeResponseTest.php
+++ b/tests/Message/ServerAuthorizeResponseTest.php
@@ -44,4 +44,14 @@ class ServerAuthorizeResponseTest extends TestCase
         $this->assertSame('{"VendorTxCode":"123456"}', $response->getTransactionReference());
         $this->assertSame('3082 : The Description value is too long.', $response->getMessage());
     }
+
+    public function testServerPurchaseWithToken()
+    {
+        $httpResponse = $this->getMockHttpResponse('ServerPurchaseWithToken.txt');
+        $response = new ServerAuthorizeResponse($this->getMockRequest(), $httpResponse->getBody());
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertTrue($response->isRedirect());
+        $this->assertSame('{ABCDEFGH-ABCD-ABCD-ABCD-ABCDEFGHIJKL}', $response->getToken());
+    }
 }

--- a/tests/Message/ServerTokenRegistrationCompleteRequestTest.php
+++ b/tests/Message/ServerTokenRegistrationCompleteRequestTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Omnipay\SagePay\Message;
+
+use Omnipay\Tests\TestCase;
+
+class ServerTokenRegistrationCompleteRequestTest extends TestCase
+{
+    /**
+     * @var ServerTokenRegistrationCompleteRequest
+     */
+    private $request;
+
+    private $successDetails = array(
+        'VPSTxId' => '{F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2}',
+        'VendorTxCode' => '123456789',
+        'SecurityKey' => 'JEUPDN1N7E',
+        'Vendor' => 'TestVendor'
+    );
+
+    public function setUp()
+    {
+        $this->request = new ServerTokenRegistrationCompleteRequest($this->getHttpClient(), $this->getHttpRequest());
+        $this->request->initialize(array(
+            'transactionId' => '123456789',
+            'transactionReference' => '{"VendorTxCode": "123456789", "VPSTxId": "{F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2}", "SecurityKey": "JEUPDN1N7E"}',
+            'vendor' => 'TestVendor'
+        ));
+    }
+
+    public function testCorrectDataUponSuccessfulSagePayRequest()
+    {
+        $expectedToken = '{ABCDE-ABCDE-ABCDE-ACBCDE}';
+
+        $signature = $this->generateSignature(
+            'F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2',
+            $this->successDetails['VendorTxCode'],
+            'OK',
+            $this->successDetails['Vendor'],
+            $expectedToken,
+            $this->successDetails['SecurityKey']
+        );
+
+        $request = $this->getHttpRequest()->request;
+        $request->set('Status', 'OK');
+        $request->set('Token', $expectedToken);
+        $request->set('VPSSignature', $signature);
+        $request->set('CardType', 'VISA');
+        $request->set('ExpiryDate', '1220');
+
+        $data = $this->request->getData();
+
+        $this->assertSame($expectedToken, $data['Token']);
+        $this->assertSame('VISA', $data['CardType']);
+        $this->assertSame('1220', $data['ExpiryDate']);
+    }
+
+    /**
+     * @expectedException \Omnipay\Common\Exception\InvalidResponseException
+     * @throws \Omnipay\Common\Exception\InvalidResponseException
+     */
+    public function testThrowsInvalidResponseUponIncorrectSagePayRequest()
+    {
+        $signature = 'adfm49cmexkgi2lddlqmtrbv';
+        $request = $this->getHttpRequest()->request;
+        $request->set('Status', 'OK');
+        $request->set('Token', '{ABCDE-ABCDE-ABCDE-ACBCDE}');
+        $request->set('VPSSignature', $signature);
+        $request->set('CardType', 'VISA');
+        $request->set('ExpiryDate', '1220');
+
+        $this->request->getData();
+    }
+
+    private function generateSignature($vpsTxId, $vendorTxCode, $status, $vendor, $token, $securityKey)
+    {
+        return md5($vpsTxId . $vendorTxCode . $status . $vendor . $token . $securityKey);
+    }
+}

--- a/tests/Message/ServerTokenRegistrationCompleteResponseTest.php
+++ b/tests/Message/ServerTokenRegistrationCompleteResponseTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Omnipay\SagePay\Message;
+
+use Omnipay\Tests\TestCase;
+use Mockery as m;
+
+class ServerTokenRegistrationCompleteResponseTest extends TestCase
+{
+    public function testTokenRegistrationCompleteResponseSuccess()
+    {
+        $response = new ServerTokenRegistrationCompleteResponse($this->getMockRequest(), array(
+            'Status' => 'OK',
+        ));
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+    }
+
+    public function testTokenRegistrationCompleteResponseInvalid()
+    {
+        $response = new ServerTokenRegistrationCompleteResponse($this->getMockRequest(), array(
+            'Status' => 'INVALID'
+        ));
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+    }
+
+    public function testTokenRegistrationCompleteResponseError()
+    {
+        $response = new ServerTokenRegistrationCompleteResponse($this->getMockRequest(), array(
+            'Status' => 'ERROR'
+        ));
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+    }
+
+    public function testConfirm()
+    {
+        $response = m::mock('\Omnipay\SagePay\Message\ServerTokenRegistrationCompleteResponse')->makePartial();
+        $response->shouldReceive('sendResponse')->once()->with('OK', 'https://www.example.com/', 'detail');
+
+        $response->confirm('https://www.example.com/', 'detail');
+    }
+
+    public function testError()
+    {
+        $response = m::mock('\Omnipay\SagePay\Message\ServerTokenRegistrationCompleteResponse')->makePartial();
+        $response->shouldReceive('sendResponse')->once()->with('ERROR', 'https://www.example.com/', 'detail');
+
+        $response->error('https://www.example.com/', 'detail');
+    }
+
+    public function testInvalid()
+    {
+        $response = m::mock('\Omnipay\SagePay\Message\ServerTokenRegistrationCompleteResponse')->makePartial();
+        $response->shouldReceive('sendResponse')->once()->with('INVALID', 'https://www.example.com/', 'detail');
+
+        $response->invalid('https://www.example.com/', 'detail');
+    }
+
+    public function testSendResponse()
+    {
+        $response = m::mock('\Omnipay\SagePay\Message\ServerTokenRegistrationCompleteResponse')->makePartial();
+        $response->shouldReceive('exitWith')->once()->with("Status=FOO\r\nRedirectUrl=https://www.example.com/");
+
+        $response->sendResponse('FOO', 'https://www.example.com/');
+    }
+
+    public function testSendResponseDetail()
+    {
+        $response = m::mock('\Omnipay\SagePay\Message\ServerTokenRegistrationCompleteResponse')->makePartial();
+        $response->shouldReceive('exitWith')->once()->with("Status=FOO\r\nRedirectUrl=https://www.example.com/\r\nStatusDetail=Bar");
+
+        $response->sendResponse('FOO', 'https://www.example.com/', 'Bar');
+    }
+}

--- a/tests/Message/ServerTokenRegistrationRequestTest.php
+++ b/tests/Message/ServerTokenRegistrationRequestTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Omnipay\SagePay\Message;
+
+use Omnipay\Tests\TestCase;
+use Mockery as m;
+
+class ServerTokenRegistrationRequestTest extends TestCase
+{
+    /**
+     * @var ServerTokenRegistrationRequest
+     */
+    private $request;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->request = new ServerTokenRegistrationRequest($this->getHttpClient(), $this->getHttpRequest());
+        $this->request->initialize(
+            array(
+                'vendor' => 'the_vendor',
+                'transactionId' => '123',
+                'returnUrl' => 'http://notifyme.com'
+            )
+        );
+    }
+
+    public function testRequestDataIsCorrect()
+    {
+        $data = $this->request->getData();
+
+        // Key assertion is that we are passing this TxType parameter in the request
+        $this->assertSame('TOKEN', $data['TxType']);
+
+        $this->assertSame('3.00', $data['VPSProtocol']);
+        $this->assertSame('the_vendor', $data['Vendor']);
+        $this->assertSame('123', $data['VendorTxCode']);
+        $this->assertSame('http://notifyme.com', $data['NotificationURL']);
+    }
+}

--- a/tests/Message/ServerTokenRegistrationResponseTest.php
+++ b/tests/Message/ServerTokenRegistrationResponseTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Omnipay\SagePay\Message;
+
+use Omnipay\Tests\TestCase;
+
+class ServerTokenRegistrationResponseTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->getMockRequest()->shouldReceive('getTransactionId')->andReturn('123456');
+    }
+
+    public function testTokenRegistrationSuccess()
+    {
+        $httpResponse = $this->getMockHttpResponse('ServerTokenRegistrationSuccess.txt');
+        $response = new ServerTokenRegistrationResponse($this->getMockRequest(), $httpResponse->getBody());
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertTrue($response->isRedirect());
+        $this->assertSame('{"SecurityKey":"IK776BWNHN","VPSTxId":"{1E7D9C70-DBE2-4726-88EA-D369810D801D}","VendorTxCode":"123456"}', $response->getTransactionReference());
+        $this->assertSame('Server transaction registered successfully.', $response->getMessage());
+        $this->assertSame('https://test.sagepay.com/Simulator/VSPServerPaymentPage.asp?TransactionID={1E7D9C70-DBE2-4726-88EA-D369810D801D}', $response->getRedirectUrl());
+        $this->assertSame('GET', $response->getRedirectMethod());
+        $this->assertNull($response->getRedirectData());
+    }
+
+    public function testTokenRegistrationFailure()
+    {
+        $httpResponse = $this->getMockHttpResponse('ServeRTokenRegistrationFailure.txt');
+        $response = new ServerTokenRegistrationResponse($this->getMockRequest(), $httpResponse->getBody());
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertSame('{"VendorTxCode":"123456"}', $response->getTransactionReference());
+        $this->assertSame('3082 : The Description value is too long.', $response->getMessage());
+    }
+}

--- a/tests/Message/ServerTokenRegistrationResponseTest.php
+++ b/tests/Message/ServerTokenRegistrationResponseTest.php
@@ -27,7 +27,7 @@ class ServerTokenRegistrationResponseTest extends TestCase
 
     public function testTokenRegistrationFailure()
     {
-        $httpResponse = $this->getMockHttpResponse('ServeRTokenRegistrationFailure.txt');
+        $httpResponse = $this->getMockHttpResponse('ServerTokenRegistrationFailure.txt');
         $response = new ServerTokenRegistrationResponse($this->getMockRequest(), $httpResponse->getBody());
 
         $this->assertFalse($response->isSuccessful());

--- a/tests/Message/TokenRemovalRequestTest.php
+++ b/tests/Message/TokenRemovalRequestTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Omnipay\SagePay\Message;
+
+use Omnipay\Tests\TestCase;
+
+class TokenRemovalRequestTest extends TestCase
+{
+    /**
+     * @var TokenRemovalRequest
+     */
+    private $request;
+
+    public function setUp()
+    {
+        $this->request = new TokenRemovalRequest($this->getHttpClient(), $this->getHttpRequest());
+        $this->request->initialize(array(
+            'vendor' => 'testvendor',
+            'token' => '{ABCDE-ABCD-ABCD-ABCD-ABCDE}'
+        ));
+    }
+
+    public function testGetData()
+    {
+        $data = $this->request->getData();
+
+        $this->assertSame('{ABCDE-ABCD-ABCD-ABCD-ABCDE}', $data['Token']);
+        $this->assertSame('REMOVETOKEN', $data['TxType']);
+        $this->assertSame('3.00', $data['VPSProtocol']);
+        $this->assertSame('testvendor', $data['Vendor']);
+        $this->assertArrayNotHasKey('AccountType', $data);
+    }
+}

--- a/tests/Mock/DirectPurchaseWithToken.txt
+++ b/tests/Mock/DirectPurchaseWithToken.txt
@@ -1,0 +1,21 @@
+HTTP/1.1 200 OK
+Date: Sat, 16 Feb 2013 06:39:41 GMT
+Server: Microsoft-IIS/6.0
+P3P: CP="CUR"
+X-Powered-By: ASP.NET
+Content-Length: 249
+Content-Type: Text/Plain
+Set-Cookie: ASPSESSIONIDSEHSCTTR=CIMGGPBDFDIKICAGIIHCNFHJ; secure; path=/
+Cache-control: private
+
+VPSProtocol=3.00
+Status=OK
+StatusDetail=Direct transaction from Simulator.
+VPSTxId={5A1BC414-5409-48DD-9B8B-DCDF096CE0BE}
+SecurityKey=OUWLNYQTVT
+TxAuthNo=9962
+AVSCV2=ALL MATCH
+AddressResult=MATCHED
+PostCodeResult=MATCHED
+CV2Result=MATCHED
+Token={ABCDEFGH-ABCD-ABCD-ABCD-ABCDEFGHIJKL}

--- a/tests/Mock/ServerPurchaseWithToken.txt
+++ b/tests/Mock/ServerPurchaseWithToken.txt
@@ -1,0 +1,17 @@
+HTTP/1.1 200 OK
+Date: Sat, 16 Feb 2013 09:02:04 GMT
+Server: Microsoft-IIS/6.0
+P3P: CP="CUR"
+X-Powered-By: ASP.NET
+Content-Length: 281
+Content-Type: Text/Plain
+Set-Cookie: ASPSESSIONIDSEHSCTTR=JAEHGPBDBOBICGBGJEHFJHPE; secure; path=/
+Cache-control: private
+
+VPSProtocol=3.00
+Status=OK
+StatusDetail=Server transaction registered successfully.
+VPSTxId={1E7D9C70-DBE2-4726-88EA-D369810D801D}
+SecurityKey=IK776BWNHN
+NextURL=https://test.sagepay.com/Simulator/VSPServerPaymentPage.asp?TransactionID={1E7D9C70-DBE2-4726-88EA-D369810D801D}
+Token={ABCDEFGH-ABCD-ABCD-ABCD-ABCDEFGHIJKL}

--- a/tests/Mock/ServerTokenRegistrationFailure.txt
+++ b/tests/Mock/ServerTokenRegistrationFailure.txt
@@ -1,0 +1,11 @@
+HTTP/1.1 200 OK
+P3P: CP="CUR"
+Content-Language: en-GB
+Content-Length: 88
+Date: Tue, 20 Jan 2015 16:45:41 GMT
+Server: undisclosed
+Set-Cookie: NSC_WRE-uftu.tbhfqbz.dpn-Kbwb7=f76fde52445f8236609ebb88e4554f525455a4a4d5e0;path=/;secure;httponly
+
+VPSProtocol=3.00
+Status=INVALID
+StatusDetail=3082 : The Description value is too long.

--- a/tests/Mock/ServerTokenRegistrationSuccess.txt
+++ b/tests/Mock/ServerTokenRegistrationSuccess.txt
@@ -1,0 +1,16 @@
+HTTP/1.1 200 OK
+Date: Sat, 16 Feb 2013 09:02:04 GMT
+Server: Microsoft-IIS/6.0
+P3P: CP="CUR"
+X-Powered-By: ASP.NET
+Content-Length: 281
+Content-Type: Text/Plain
+Set-Cookie: ASPSESSIONIDSEHSCTTR=JAEHGPBDBOBICGBGJEHFJHPE; secure; path=/
+Cache-control: private
+
+VPSProtocol=3.00
+Status=OK
+StatusDetail=Server transaction registered successfully.
+VPSTxId={1E7D9C70-DBE2-4726-88EA-D369810D801D}
+SecurityKey=IK776BWNHN
+NextURL=https://test.sagepay.com/Simulator/VSPServerPaymentPage.asp?TransactionID={1E7D9C70-DBE2-4726-88EA-D369810D801D}


### PR DESCRIPTION
Fixes #61.

Includes support for both `Direct` and `Server` integration pathways. This has mostly been recycled directly from a project that I used this on so it should be working, but would probably need some extra eyes to make sure that it works when integrated with production code (and not just unit tests).