### PR TITLE
Support repeat payments

### DIFF
--- a/src/DirectGateway.php
+++ b/src/DirectGateway.php
@@ -86,4 +86,9 @@ class DirectGateway extends AbstractGateway
     {
         return $this->createRequest('\Omnipay\SagePay\Message\RefundRequest', $parameters);
     }
+
+    public function repeatPayment(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\SagePay\Message\DirectRepeatPaymentRequest', $parameters);
+    }
 }

--- a/src/Message/DirectRepeatPaymentRequest.php
+++ b/src/Message/DirectRepeatPaymentRequest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Omnipay\SagePay\Message;
+
+use Omnipay\Common\Helper;
+
+/**
+ * Sage Pay Direct Repeat Payment Request
+ */
+class DirectRepeatPaymentRequest extends AbstractRequest
+{
+    protected $action = 'REPEAT';
+
+    // --------------
+    // Public getters
+    // --------------
+
+    public function getData()
+    {
+        $data = $this->getBaseData();
+
+        // Merchant's unique reference to THIS payment
+        $data['VendorTxCode'] = $this->getTransactionId();
+
+        $data['Amount'] = $this->getAmount();
+        $data['Currency'] = 'GBP';
+        $data['Description'] = $this->getDescription();
+
+        // SagePay's unique reference for the PREVIOUS transaction
+        $data['RelatedVPSTxId'] = $this->getRelatedVPSTxId();
+        $data['RelatedVendorTxCode'] = $this->getRelatedVendorTxCode();
+        $data['RelatedSecurityKey'] = $this->getRelatedSecurityKey();
+        $data['RelatedTxAuthNo'] = $this->getRelatedTxAuthNo();
+
+        return $data;
+    }
+
+    public function getDescription()
+    {
+        return $this->getParameter('description');
+    }
+
+    public function getService()
+    {
+        return 'repeat';
+    }
+
+    // --------------
+    // Public setters
+    // --------------
+
+    public function setDescription($value)
+    {
+        return $this->setParameter('description', $value);
+    }
+
+    /**
+     * This is a direct map to Omnipay\SagePay\Message\Response::getTransactionReference()
+     *
+     * @param string $jsonEncodedReference JSON-encoded reference to the original transaction
+     */
+    public function setRelatedTransactionReference($jsonEncodedReference)
+    {
+        $unpackedReference = json_decode($jsonEncodedReference, true);
+        foreach ($unpackedReference as $parameter => $value) {
+            $methodName = 'setRelated'.$parameter;
+            if (method_exists($this, $methodName)) {
+                $this->$methodName($value);
+            }
+        }
+    }
+
+    // ----------------
+    // Internal getters
+    // ----------------
+
+    protected function getRelatedVPSTxId()
+    {
+        return $this->getParameter('relatedVPSTxId');
+    }
+
+    protected function getRelatedVendorTxCode()
+    {
+        return $this->getParameter('relatedVendorTxCode');
+    }
+
+    protected function getRelatedSecurityKey()
+    {
+        return $this->getParameter('relatedSecurityKey');
+    }
+
+    protected function getRelatedTxAuthNo()
+    {
+        return $this->getParameter('relatedTxAuthNo');
+    }
+
+    // ----------------
+    // Internal setters
+    // ----------------
+
+    protected function setRelatedSecurityKey($value)
+    {
+        return $this->setParameter('relatedSecurityKey', $value);
+    }
+
+    protected function setRelatedTxAuthNo($value)
+    {
+        return $this->setParameter('relatedTxAuthNo', $value);
+    }
+
+    protected function setRelatedVendorTxCode($value)
+    {
+        return $this->setParameter('relatedVendorTxCode', $value);
+    }
+
+    protected function setRelatedVPSTxId($value)
+    {
+        return $this->setParameter('relatedVPSTxId', $value);
+    }
+}

--- a/src/Message/DirectRepeatPaymentRequest.php
+++ b/src/Message/DirectRepeatPaymentRequest.php
@@ -11,10 +11,6 @@ class DirectRepeatPaymentRequest extends AbstractRequest
 {
     protected $action = 'REPEAT';
 
-    // --------------
-    // Public getters
-    // --------------
-
     public function getData()
     {
         $data = $this->getBaseData();
@@ -45,10 +41,6 @@ class DirectRepeatPaymentRequest extends AbstractRequest
         return 'repeat';
     }
 
-    // --------------
-    // Public setters
-    // --------------
-
     public function setDescription($value)
     {
         return $this->setParameter('description', $value);
@@ -70,10 +62,6 @@ class DirectRepeatPaymentRequest extends AbstractRequest
         }
     }
 
-    // ----------------
-    // Internal getters
-    // ----------------
-
     protected function getRelatedVPSTxId()
     {
         return $this->getParameter('relatedVPSTxId');
@@ -93,10 +81,6 @@ class DirectRepeatPaymentRequest extends AbstractRequest
     {
         return $this->getParameter('relatedTxAuthNo');
     }
-
-    // ----------------
-    // Internal setters
-    // ----------------
 
     protected function setRelatedSecurityKey($value)
     {

--- a/tests/Message/DirectRepeatPaymentRequestTest.php
+++ b/tests/Message/DirectRepeatPaymentRequestTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Omnipay\SagePay\Message;
+
+use Omnipay\Tests\TestCase;
+
+class DirectRepeatPaymentRequestTest extends TestCase
+{
+    /**
+     * @var \Omnipay\SagePay\Message\DirectRepeatPaymentRequest $request
+     */
+    protected $request;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->request = new DirectRepeatPaymentRequest($this->getHttpClient(), $this->getHttpRequest());
+        $this->request->initialize(
+            array(
+                'amount' => '12.00',
+                'currency' => 'GBP',
+                'transactionId' => '123',
+            )
+        );
+    }
+
+    public function testSettingOfRelatedTransaction()
+    {
+        $relatedTransactionRef =
+            '{"SecurityKey":"F6AF4AIB1G","TxAuthNo":"1518884596","VPSTxId":"{9EC5D0BC-A816-E8C3-859A-55C1E476E7C2}","VendorTxCode":"D6429BY7x2217743"}';
+        $this->request->setRelatedTransactionReference($relatedTransactionRef);
+        $data = $this->request->getData();
+
+        $this->assertEquals('12.00', $data['Amount'], 'Transaction amount does not match');
+        $this->assertEquals('GBP', $data['Currency'], 'Currency code does not match');
+        $this->assertEquals('123', $data['VendorTxCode'], 'Transaction ID does not match');
+        $this->assertEquals('F6AF4AIB1G', $data['RelatedSecurityKey'], 'Security Key does not match');
+        $this->assertEquals('{9EC5D0BC-A816-E8C3-859A-55C1E476E7C2}', $data['RelatedVPSTxId'],
+            'Related VPSTxId does not match');
+        $this->assertEquals('D6429BY7x2217743', $data['RelatedVendorTxCode'], 'Related VendorTxCode does not match');
+        $this->assertEquals('1518884596', $data['RelatedTxAuthNo'], 'Related TxAuthNo does not match');
+    }
+}


### PR DESCRIPTION
Repeat payments allow you to take a further payment against a customer's card, just using the previous transaction's reference, and the new amount. Very useful for various e-commerce and subscription applications.