### PR TITLE
Support old-style basket for Sage integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ The following gateways are provided by this package:
 For general usage instructions, please see the main [Omnipay](https://github.com/thephpleague/omnipay)
 repository.
 
+### Basket format
+
+By default [BasketXML](http://www.sagepay.co.uk/support/12/36/protocol-3-00-basket-xml) (Protocol 3.00) field will be sent (if item data is available) with the requests. However, a parameter "useOldBasketFormat" with value of TRUE can be passed to the config, which will in turn send old format [Basket](http://www.sagepay.co.uk/support/error-codes/3021-invalid-basket-format-invalid) field. Old format can be used to enable other Sage products better integrate with Sage Pay, as new BasketXML is not yet supported.
+
 ## Support
 
 If you are having general issues with Omnipay, we suggest posting on

--- a/README.md
+++ b/README.md
@@ -39,7 +39,11 @@ repository.
 
 ### Basket format
 
-By default [BasketXML](http://www.sagepay.co.uk/support/12/36/protocol-3-00-basket-xml) (Protocol 3.00) field will be sent (if item data is available) with the requests. However, a parameter "useOldBasketFormat" with value of TRUE can be passed to the config, which will in turn send old format [Basket](http://www.sagepay.co.uk/support/error-codes/3021-invalid-basket-format-invalid) field. Old format can be used to enable other Sage products better integrate with Sage Pay, as new BasketXML is not yet supported.
+Sagepay currently supports two different formats for sending cart/item information to them:  
+ - [BasketXML](http://www.sagepay.co.uk/support/12/36/protocol-3-00-basket-xml)
+ - [Basket](http://www.sagepay.co.uk/support/error-codes/3021-invalid-basket-format-invalid)
+
+These are incompatible with each other, and cannot be both sent in the same transaction. *BasketXML* is the most modern format, and is the default used by this driver. *Basket* is an older format which may be deprecated one day, but is also the only format currently supported by some of the Sage accounting products (Line 50, etc) which can pull transaction data directly from Sagepay. Therefore for users who require this type of integration, an optional parameter `useOldBasketFormat` with a value of `true` can be passed in the driver's `initialize()` method.
 
 ## Support
 

--- a/src/DirectGateway.php
+++ b/src/DirectGateway.php
@@ -36,6 +36,17 @@ class DirectGateway extends AbstractGateway
     {
         return $this->setParameter('vendor', $value);
     }
+    
+    public function setUseOldBasketFormat($value){
+        $value = (bool)$value;
+        return $this->setParameter('useOldBasketFormat', $value);
+    }
+
+    public function getUseOldBasketFormat(){
+        $var = $this->getParameter('useOldBasketFormat');
+        if(!empty($var)) return true;
+        return false;
+    }
 
     // Access to the HTTP client for debugging.
     // NOTE: this is likely to be removed or replaced with something

--- a/src/DirectGateway.php
+++ b/src/DirectGateway.php
@@ -43,9 +43,7 @@ class DirectGateway extends AbstractGateway
     }
 
     public function getUseOldBasketFormat(){
-        $var = $this->getParameter('useOldBasketFormat');
-        if(!empty($var)) return true;
-        return false;
+        return $this->getParameter('useOldBasketFormat');
     }
 
     // Access to the HTTP client for debugging.

--- a/src/DirectGateway.php
+++ b/src/DirectGateway.php
@@ -37,12 +37,15 @@ class DirectGateway extends AbstractGateway
         return $this->setParameter('vendor', $value);
     }
     
-    public function setUseOldBasketFormat($value){
+    public function setUseOldBasketFormat($value)
+    {
         $value = (bool)$value;
+
         return $this->setParameter('useOldBasketFormat', $value);
     }
 
-    public function getUseOldBasketFormat(){
+    public function getUseOldBasketFormat()
+    {
         return $this->getParameter('useOldBasketFormat');
     }
 

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -27,12 +27,15 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return $this->action;
     }
     
-    public function setUseOldBasketFormat($value){
+    public function setUseOldBasketFormat($value)
+    {
         $value = (bool)$value;
+
         return $this->setParameter('useOldBasketFormat', $value);
     }
 
-    public function getUseOldBasketFormat(){
+    public function getUseOldBasketFormat()
+    {
         return $this->getParameter('useOldBasketFormat');
     }
 
@@ -250,13 +253,14 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
      * 1:Item:2:10.00:0.00:10.00:20.00
      * [number of lines]:[item name]:[quantity]:[unit cost]:[item tax]:[item total]:[line total]
      */
-    protected function getItemDataNonXML(){
+    protected function getItemDataNonXML()
+    {
 
         $result = '';
         $items = $this->getItems();
         $count = 0;
 
-        foreach($items as $basketItem){
+        foreach ($items as $basketItem) {
             $lineTotal = ($basketItem->getQuantity() * $basketItem->getPrice());
 
             $description = $this->filterItemName($basketItem->getName());
@@ -276,7 +280,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         }
 
         // Prepend number of lines to the result string
-        $result = $count.$result;
+        $result = $count . $result;
 
         return $result;
 

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -26,6 +26,15 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     {
         return $this->action;
     }
+    
+    public function setUseOldBasketFormat($value){
+        $value = (bool)$value;
+        return $this->setParameter('useOldBasketFormat', $value);
+    }
+
+    public function getUseOldBasketFormat(){
+        return $this->getParameter('useOldBasketFormat')
+    }
 
     public function getAccountType()
     {

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -33,7 +33,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     }
 
     public function getUseOldBasketFormat(){
-        return $this->getParameter('useOldBasketFormat')
+        return $this->getParameter('useOldBasketFormat');
     }
 
     public function getAccountType()

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -233,4 +233,43 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
 
         return $result;
     }
+    
+    /**
+     * Generate Basket string in the old format
+     * This is called if "useOldBasketFormat" is set to true in the gateway config
+     * @return string Basket field in format of:
+     * 1:Item:2:10.00:0.00:10.00:20.00
+     * [number of lines]:[item name]:[quantity]:[unit cost]:[item tax]:[item total]:[line total]
+     */
+    protected function getItemDataNonXML(){
+
+        $result = '';
+        $items = $this->getItems();
+        $count = 0;
+
+        foreach($items as $basketItem){
+            $lineTotal = ($basketItem->getQuantity() * $basketItem->getPrice());
+
+            $description = $this->filterItemName($basketItem->getName());
+            $description = str_replace(':', ' ', $description); // Make sure there aren't any colons in the name
+            // Perhaps : should be replaced with '-' or other symbol?
+
+            $result .= ':' . $description .    // Item name
+                ':' . $basketItem->getQuantity() . // Quantity
+                ':' . number_format($basketItem->getPrice(), 2, '.', '') .    // Unit cost (without tax)
+                ':0.00' .    // Item tax
+                ':' . number_format($basketItem->getPrice(), 2, '.', '') .    // Item total
+                ':' . number_format($lineTotal);  // Line total
+            // As the getItemData() puts 0.00 into tax, same was done here
+
+            $count++;
+
+        }
+
+        // Prepend number of lines to the result string
+        $result = $count.$result;
+
+        return $result;
+
+    }
 }

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -272,7 +272,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
                 ':' . number_format($basketItem->getPrice(), 2, '.', '') .    // Unit cost (without tax)
                 ':0.00' .    // Item tax
                 ':' . number_format($basketItem->getPrice(), 2, '.', '') .    // Item total
-                ':' . number_format($lineTotal);  // Line total
+                ':' . number_format($lineTotal, 2, '.', '');  // Line total
             // As the getItemData() puts 0.00 into tax, same was done here
 
             $count++;

--- a/src/Message/DirectAuthorizeRequest.php
+++ b/src/Message/DirectAuthorizeRequest.php
@@ -54,12 +54,12 @@ class DirectAuthorizeRequest extends AbstractRequest
         $data['DeliveryPhone'] = $card->getShippingPhone();
         $data['CustomerEMail'] = $card->getEmail();
 
-        if($this->getUseOldBasketFormat()){
+        if ($this->getUseOldBasketFormat()) {
             $basket = $this->getItemDataNonXML();
-            if(!empty($basket)){
+            if (!empty($basket)) {
                 $data['Basket'] = $basket;
             }
-        }else{
+        } else {
             $basketXML = $this->getItemData();
             if (!empty($basketXML)) {
                 $data['BasketXML'] = $basketXML;

--- a/src/Message/DirectAuthorizeRequest.php
+++ b/src/Message/DirectAuthorizeRequest.php
@@ -54,9 +54,16 @@ class DirectAuthorizeRequest extends AbstractRequest
         $data['DeliveryPhone'] = $card->getShippingPhone();
         $data['CustomerEMail'] = $card->getEmail();
 
-        $basketXML = $this->getItemData();
-        if (!empty($basketXML)) {
-            $data['BasketXML'] = $basketXML;
+        if($this->getUseOldBasketFormat()){
+            $basket = $this->getItemDataNonXML();
+            if(!empty($basket)){
+                $data['Basket'] = $basket;
+            }
+        }else{
+            $basketXML = $this->getItemData();
+            if (!empty($basketXML)) {
+                $data['BasketXML'] = $basketXML;
+            }
         }
 
         return $data;


### PR DESCRIPTION
Resolves #55. Allows you to optionally pass a parameter to force the driver to use the old-style basket format. Currently this is the only format supported by various Sage products such as Line 50, and so is preferable for merchants wishing to automate the import of SagePay transactions into Sage.