### PR TITLE
PR79 plus unit test

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -27,6 +27,16 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return $this->setParameter('vendor', $value);
     }
 
+    public function getVendorData()
+    {
+        return $this->getParameter('vendorData');
+    }
+
+    public function setVendorData($value)
+    {
+        return $this->setParameter('vendorData', $value);
+    }
+
     public function getService()
     {
         return $this->action;

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -32,6 +32,9 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return $this->getParameter('vendorData');
     }
 
+    /**
+     * @param string $value ASCII alphanumeric and spaces, max 200 characters.
+     */
     public function setVendorData($value)
     {
         return $this->setParameter('vendorData', $value);

--- a/src/Message/DirectAuthorizeRequest.php
+++ b/src/Message/DirectAuthorizeRequest.php
@@ -22,6 +22,7 @@ class DirectAuthorizeRequest extends AbstractRequest
         $data['Description'] = $this->getDescription();
         $data['Amount'] = $this->getAmount();
         $data['Currency'] = $this->getCurrency();
+        $data['VendorData'] = $this->getVendorData();
         $data['VendorTxCode'] = $this->getTransactionId();
         $data['ClientIPAddress'] = $this->getClientIp();
         $data['ApplyAVSCV2'] = $this->getApplyAVSCV2() ?: 0;

--- a/tests/Message/DirectAuthorizeRequestTest.php
+++ b/tests/Message/DirectAuthorizeRequestTest.php
@@ -44,6 +44,7 @@ class DirectAuthorizeRequestTest extends TestCase
         $this->request->setDescription('food');
         $this->request->setClientIp('127.0.0.1');
         $this->request->setReferrerId('3F7A4119-8671-464F-A091-9E59EB47B80C');
+        $this->request->setVendorData('Vendor secret codes');
 
         $data = $this->request->getData();
 
@@ -56,6 +57,7 @@ class DirectAuthorizeRequestTest extends TestCase
         $this->assertSame(2, $data['ApplyAVSCV2']);
         $this->assertSame(3, $data['Apply3DSecure']);
         $this->assertSame('3F7A4119-8671-464F-A091-9E59EB47B80C', $data['ReferrerID']);
+        $this->assertSame('Vendor secret codes', $data['VendorData']);
     }
 
     public function testNoBasket()


### PR DESCRIPTION
Added test to #PR79 to confirm vendor data is set.

Example response from the gateway if the vendor data contains any non-alphanumeric characters:

> ["Status"]=>string(7) "INVALID"
> ["StatusDetail"]=>string(34) "3189 : The vendor data is invalid."
