### PR TITLE
Allow setting cardholder name directly

### DIFF
--- a/src/Message/DirectAuthorizeRequest.php
+++ b/src/Message/DirectAuthorizeRequest.php
@@ -98,12 +98,29 @@ class DirectAuthorizeRequest extends AbstractRequest
         return $ip;
     }
 
+    /*
+     * Set cardholder name directly, overriding the billing name and surname of the card.
+     */
+    public function setCardholderName($value)
+    {
+        return $this->setParameter('cardholderName', $value);
+    }
+
+    public function getCardholderName()
+    {
+        return $this->getParameter('cardholderName');
+    }
+
     public function getData()
     {
         $data = $this->getBaseAuthorizeData();
         $this->getCard()->validate();
 
-        $data['CardHolder'] = $this->getCard()->getName();
+        if ($this->getCardholderName()) {
+            $data['CardHolder'] = $this->getCardholderName();
+        } else {
+            $data['CardHolder'] = $this->getCard()->getName();
+        }
 
         // Card number should not be provided if token is being provided instead
         if (!$this->getToken()) {

--- a/tests/Message/DirectAuthorizeRequestTest.php
+++ b/tests/Message/DirectAuthorizeRequestTest.php
@@ -45,6 +45,7 @@ class DirectAuthorizeRequestTest extends TestCase
         $this->request->setClientIp('127.0.0.1');
         $this->request->setReferrerId('3F7A4119-8671-464F-A091-9E59EB47B80C');
         $this->request->setVendorData('Vendor secret codes');
+        $this->request->setCardholderName('Mr E User');
 
         $data = $this->request->getData();
 
@@ -58,6 +59,7 @@ class DirectAuthorizeRequestTest extends TestCase
         $this->assertSame(3, $data['Apply3DSecure']);
         $this->assertSame('3F7A4119-8671-464F-A091-9E59EB47B80C', $data['ReferrerID']);
         $this->assertSame('Vendor secret codes', $data['VendorData']);
+        $this->assertSame('Mr E User', $data['CardHolder']);
     }
 
     public function testNoBasket()


### PR DESCRIPTION
Fixes #81

I used the same getter & setter as omnipay-braintree.

Barring major changes to Omnipay Common this seems like the least worst solution.