### PR TITLE
Support SurchargeXML field

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
+  - 7.1
   - hhvm
 
 before_script:

--- a/src/Message/DirectAuthorizeRequest.php
+++ b/src/Message/DirectAuthorizeRequest.php
@@ -79,6 +79,12 @@ class DirectAuthorizeRequest extends AbstractRequest
             }
         }
 
+        $surchargeXml = $this->getSurchargeXml();
+
+        if ($surchargeXml) {
+            $data['surchargeXml'] = $this->getSurchargeXml();
+        }
+
         return $data;
     }
 
@@ -156,5 +162,24 @@ class DirectAuthorizeRequest extends AbstractRequest
         }
 
         return $brand;
+    }
+
+    /**
+     * Set the raw surcharge XML field.
+     *
+     * @param string $surchargeXml The XML data formatted as per Sage Pay documentation.
+     * @return $this
+     */
+    public function setSurchargeXml($surchargeXml)
+    {
+        return $this->setParameter('surchargeXml', $surchargeXml);
+    }
+
+    /**
+     * @return string The XML surchange data as set.
+     */
+    public function getSurchargeXml()
+    {
+        return $this->getParameter('surchargeXml');
     }
 }

--- a/src/Message/ServerPurchaseRequest.php
+++ b/src/Message/ServerPurchaseRequest.php
@@ -10,24 +10,9 @@ class ServerPurchaseRequest extends ServerAuthorizeRequest
 
     protected $action = 'PAYMENT';
 
-    public function setSurchargeXml($surchargeXml)
-    {
-        $this->setParameter('surchargeXml', $surchargeXml);
-    }
-
-    public function getSurchargeXml()
-    {
-        return $this->getParameter('surchargeXml');
-    }
-
     public function getData()
     {
         $data = parent::getData();
-
-        $surchargeXml = $this->getSurchargeXml();
-        if ($surchargeXml) {
-            $data['surchargeXml'] = $this->getSurchargeXml();
-        }
 
         return $data;
     }

--- a/tests/Message/DirectAuthorizeRequestTest.php
+++ b/tests/Message/DirectAuthorizeRequestTest.php
@@ -6,6 +6,8 @@ use Omnipay\Tests\TestCase;
 
 class DirectAuthorizeRequestTest extends TestCase
 {
+    const SURCHARGE_XML = '<surcharges><surcharge><paymentType>VISA</paymentType><percentage>2.50</percentage></surcharge></surcharges>';
+
     /**
      * @var \Omnipay\Common\Message\AbstractRequest $request
      */
@@ -21,6 +23,7 @@ class DirectAuthorizeRequestTest extends TestCase
                 'amount' => '12.00',
                 'currency' => 'GBP',
                 'transactionId' => '123',
+                'surchargeXml' => self::SURCHARGE_XML,
                 'card' => $this->getValidCard(),
             )
         );
@@ -60,6 +63,7 @@ class DirectAuthorizeRequestTest extends TestCase
         $this->assertSame('3F7A4119-8671-464F-A091-9E59EB47B80C', $data['ReferrerID']);
         $this->assertSame('Vendor secret codes', $data['VendorData']);
         $this->assertSame('Mr E User', $data['CardHolder']);
+        $this->assertSame(self::SURCHARGE_XML, $data['surchargeXml']);
     }
 
     public function testNoBasket()

--- a/tests/Message/ServerAuthorizeRequestTest.php
+++ b/tests/Message/ServerAuthorizeRequestTest.php
@@ -6,6 +6,8 @@ use Omnipay\Tests\TestCase;
 
 class ServerAuthorizeRequestTest extends TestCase
 {
+    const SURCHARGE_XML = '<surcharges><surcharge><paymentType>VISA</paymentType><percentage>2.50</percentage></surcharge></surcharges>';
+
     public function setUp()
     {
         parent::setUp();
@@ -15,7 +17,10 @@ class ServerAuthorizeRequestTest extends TestCase
             array(
                 'amount' => '12.00',
                 'transactionId' => '123',
+                'surchargeXml' => self::SURCHARGE_XML,
                 'card' => $this->getValidCard(),
+                'notifyUrl' => 'https://www.example.com/return',
+                'profile' => 'LOW',
             )
         );
     }
@@ -26,11 +31,12 @@ class ServerAuthorizeRequestTest extends TestCase
         $this->assertSame('NORMAL', $this->request->getProfile());
     }
 
-    public function getData()
+    public function testGetData()
     {
         $data = $this->request->getData();
 
         $this->assertSame('https://www.example.com/return', $data['NotificationURL']);
         $this->assertSame('LOW', $data['Profile']);
+        $this->assertSame(self::SURCHARGE_XML, $data['surchargeXml']);
     }
 }

--- a/tests/Message/ServerPurchaseRequestTest.php
+++ b/tests/Message/ServerPurchaseRequestTest.php
@@ -23,7 +23,6 @@ class ServerPurchaseRequestTest extends TestCase
         );
 
         $data = $request->getData();
-        $this->assertSame(self::SURCHARGE_XML, $data['surchargeXml']);
     }
 
     public function testSetSurchargeXml()


### PR DESCRIPTION
This supports the raw XML field, which contains XML as a string, up to 800 ASCII characters long. There is no validation on the format or validity; it is just passed on to the gateway with any transaction, Server and Direct, authorize or purchase.