### PR TITLE
Extend item to include VAT property

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,22 @@ Authorize.Net calls it the "business model" and includes "retail" as an option, 
 to card machines and hand-held scanners. This is not yet standardised in Omnipay, but
 there are some moves to do so.
 
+# VAT
+
+If you want to include VAT amount in the item array you must use `\Omnipay\SagePay\Extend\Item` as follows.
+
+```php
+$items = array(
+    array(new \Omnipay\SagePay\Extend\Item(array(
+        'name' => 'My Product Name',
+        'description' => 'My Product Description',
+        'quantity' => 1,
+        'price' => 9.99,
+        'vat' => 1.665, // VAT amount, not percentage
+    ))
+);
+```
+
 # Sage Pay Server Notification Handler
 
 > **NOTE:** The notification handler was previously handled by the SagePay_Server `completeAuthorize`,
@@ -464,8 +480,19 @@ The URL for the notification handler is set in the authorize or payment message:
 // The Server response will be a redirect to the Sage Pay CC form.
 // This is a Sage Pay Server Purchase request.
 
+$transactionId = time(); // Your transaction id
+
+$items = array(
+    array(
+        'name' => 'My Product Name',
+        'description' => 'My Product Description',
+        'quantity' => 1,
+        'price' => 9.99,
+    )
+);
+
 $response = $gateway->purchase(array(
-    'amount' => '9.99',
+    'amount' => 9.99,
     'currency' => 'GBP',
     'card' => $card, // Just the name and address, NOT CC details.
     'notifyUrl' => route('sagepay.server.notify'), // The route to your application's notification handler.

--- a/src/Extend/Item.php
+++ b/src/Extend/Item.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Omnipay\SagePay\Extend;
+
+/**
+ * Extends the Item class to support properties
+ */
+
+use Omnipay\Common\Item as CommonItem;
+
+class Item extends CommonItem implements ItemInterface
+{
+   /**
+     * {@inheritDoc}
+     */
+    public function getVat()
+    {
+        return $this->getParameter('vat');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setVat($value)
+    {
+        return $this->setParameter('vat', $value);
+    }
+}

--- a/src/Extend/ItemInterface.php
+++ b/src/Extend/ItemInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Omnipay\SagePay\Extend;
+
+/**
+ * Extends the Item class to support properties
+ */
+
+use Omnipay\Common\ItemInterface as CommonItemInterface;
+
+interface ItemInterface extends CommonItemInterface
+{
+    /**
+     * Set the item VAT.
+     */
+    public function setVat($value);
+
+    /**
+     * Get the item VAT.
+     */
+    public function getVat();
+}

--- a/tests/Message/DirectAuthorizeRequestTest.php
+++ b/tests/Message/DirectAuthorizeRequestTest.php
@@ -118,6 +118,34 @@ class DirectAuthorizeRequestTest extends TestCase
         $this->assertContains($basketXml, $data['BasketXML']);
     }
 
+    public function testBasketExtendItem()
+    {
+        $items = new \Omnipay\Common\ItemBag(array(
+            new \Omnipay\SagePay\Extend\Item(array(
+                'name' => 'Name',
+                'description' => 'Description',
+                'quantity' => 1,
+                'price' => 1.23,
+                'vat' => 0.205,
+            ))
+        ));
+
+        $basketXml = '<basket><item>'
+            . '<description>Name</description><quantity>1</quantity>'
+            . '<unitNetAmount>1.23</unitNetAmount><unitTaxAmount>0.205</unitTaxAmount>'
+            . '<unitGrossAmount>1.435</unitGrossAmount><totalGrossAmount>1.435</totalGrossAmount>'
+            . '</item></basket>';
+
+        $this->request->setItems($items);
+
+        $data = $this->request->getData();
+
+        // The element does exist, and must contain the basket XML, with optional XML header and
+        // trailing newlines.
+        $this->assertArrayHasKey('BasketXML', $data);
+        $this->assertContains($basketXml, $data['BasketXML']);
+    }
+
     public function testGetDataNoReferrerId()
     {
         // Default value is equivalent to this:


### PR DESCRIPTION
Closes #85

Note that I set the VAT property to be amount instead of percentage, the reason is because of decimals.