### PR TITLE
Composer: Remove `branch-alias`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,10 +35,5 @@
     },
     "require-dev": {
         "omnipay/tests": "~2.0"
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "2.0.x-dev"
-        }
     }
 }


### PR DESCRIPTION
Remove `branch-alias` from `composer.json` because the `2.0.x-dev` branch doesn't exist anymore.