### PR TITLE
Issue #107 - Basket Format - Sage 50 Accounts fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Table of Contents
       * [Generating a Token or CardReference](#generating-a-token-or-cardreference)
       * [Using a Token or CardRererence](#using-a-token-or-cardrererence)
    * [Basket format](#basket-format)
+      * [Sage 50 Accounts Software Integration](#sage-50-accounts-software-integration)
    * [Account Types](#account-types)
    * [Sage Pay Server Notification Handler](#sage-pay-server-notification-handler)
    * [Support](#support)
@@ -428,6 +429,24 @@ but is also the only format currently supported by some of the Sage accounting p
 (e.g. Line 50) which can pull transaction data directly from Sage Pay.
 For applications that require this type of integration, an optional parameter `useOldBasketFormat`
 with a value of `true` can be passed in the driver's `initialize()` method.
+
+## Sage 50 Accounts Software Integration
+
+ The Basket format can be used for Sage 50 Accounts Software Integration:
+ > It is possible to integrate your Sage Pay account with Sage Accounting products to ensure you can
+> reconcile the transactions on your account within your financial software.
+> If you wish to link a transaction to a specific product record this can be done through the Basket field
+  in the transaction registration post.
+> Please note the following integration is not currently available when using BasketXML fields. 
+> In order for the download of transactions to affect a product record the first entry in a basket line needs
+  to be the product code of the item within square brackets. For example:
+  
+```
+4:[PR001]Pioneer NSDV99 DVD-Surround Sound System:1:424.68:74.32:499.00:499.00
+```
+ You can either prepend this onto the description or using `\Omnipay\SagePay\Extend\Item` you can use `setProductCode`
+which will take care of pre-pending `[]` for you. 
+
 
 # Account Types
 

--- a/src/Extend/Item.php
+++ b/src/Extend/Item.php
@@ -25,4 +25,24 @@ class Item extends CommonItem implements ItemInterface
     {
         return $this->setParameter('vat', $value);
     }
+
+    /**
+     * Product Code is used for the Product Sage 50 Accounts Software Integration
+     * It allows reconcile the transactions on your account within the financial software
+     * by linking the product record to a specific transaction.
+     * This is not available for BasketXML and only Basket Integration. See docs for more info.
+     * {@inheritDoc}
+     */
+    public function getProductRecord()
+    {
+        return $this->getParameter('productRecord');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setProductRecord($value)
+    {
+        return $this->setParameter('productRecord', $value);
+    }
 }

--- a/src/Extend/Item.php
+++ b/src/Extend/Item.php
@@ -33,16 +33,16 @@ class Item extends CommonItem implements ItemInterface
      * This is not available for BasketXML and only Basket Integration. See docs for more info.
      * {@inheritDoc}
      */
-    public function getProductRecord()
+    public function getProductCode()
     {
-        return $this->getParameter('productRecord');
+        return $this->getParameter('productCode');
     }
 
     /**
      * {@inheritDoc}
      */
-    public function setProductRecord($value)
+    public function setProductCode($value)
     {
-        return $this->setParameter('productRecord', $value);
+        return $this->setParameter('productCode', $value);
     }
 }

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -439,6 +439,22 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     }
 
     /**
+     * Filters out any characters that SagePay does not support from the item name for
+     * the non-xml basket integration
+     *
+     * @param string $name
+     * @return string
+     */
+    protected function filterNonXmlItemName($name)
+    {
+        $standardChars = '0-9a-zA-Z';
+        $allowedSpecialChars = " +'/\\,.-{};_@()^\"~$=!#?|[]";
+        $pattern = '`[^'.$standardChars.preg_quote($allowedSpecialChars, '/').']`';
+        $name = trim(substr(preg_replace($pattern, '', $name), 0, 100));
+        return $name;
+    }
+
+    /**
      * Filters out any characters that SagePay does not support from the item name.
      *
      * Believe it or not, SagePay actually have separate rules for allowed characters
@@ -549,14 +565,23 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         $count = 0;
 
         foreach ($items as $basketItem) {
+            $description = $this->filterNonXmlItemName($basketItem->getName());
             $vat = '0.00';
             if ($basketItem instanceof ExtendItem) {
                 $vat = $basketItem->getVat();
+
+                /**
+                 * Product Code is used for the Product Sage 50 Accounts Software Integration
+                 * It allows reconcile the transactions on your account within the financial software
+                 * by linking the product record to a specific transaction.
+                 * This is not available for BasketXML and only Basket Integration. See docs for more info.
+                 */
+                if (!is_null($basketItem->getProductRecord())) {
+                    $description = '[' . $basketItem->getProductRecord() . ']' . $description;
+                }
             }
 
             $lineTotal = ($basketItem->getQuantity() * ($basketItem->getPrice() + $vat));
-
-            $description = $this->filterItemName($basketItem->getName());
 
             // Make sure there aren't any colons in the name
             // Perhaps ":" should be replaced with '-' or other symbol?
@@ -570,7 +595,6 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
                 ':' . number_format($lineTotal, 2, '.', '');  // Line total
 
             $count++;
-
         }
 
         // Prepend number of lines to the result string

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -576,8 +576,8 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
                  * by linking the product record to a specific transaction.
                  * This is not available for BasketXML and only Basket Integration. See docs for more info.
                  */
-                if (!is_null($basketItem->getProductRecord())) {
-                    $description = '[' . $basketItem->getProductRecord() . ']' . $description;
+                if (!is_null($basketItem->getProductCode())) {
+                    $description = '[' . $basketItem->getProductCode() . ']' . $description;
                 }
             }
 

--- a/tests/Message/DirectAuthorizeRequestTest.php
+++ b/tests/Message/DirectAuthorizeRequestTest.php
@@ -357,7 +357,7 @@ class DirectAuthorizeRequestTest extends TestCase
                 'quantity' => 3,
                 'price' => 4.35,
                 'vat' => 2,
-                'productRecord' => 'DVD-123'
+                'productCode' => 'DVD-123'
             )),
         ));
         $this->request->setItems($items);


### PR DESCRIPTION
I raised an issue previously for #107  -and then raised a PR for version `3.x`. Unfortunately the package of https://github.com/craftcms/commerce-sagepay has a dependancy requires` ominipay-sagepay` version `2.x`.

I have migrated the code which had the patch for `3.x` from the original PR that I raised.
https://github.com/thephpleague/omnipay-sagepay/pull/108 

Is this something that we accept and pull into `2.x`?