### PR TITLE
Issue112 - Support Sage Pay Form

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,6 +647,7 @@ To get the result, the transaction is "completed":
 $result = $gateway->completeAuthorize()->send();
 
 $result->isSuccessful();
+$result->getTransactionReference();
 // etc.
 ```
 
@@ -658,7 +659,8 @@ and the `completePurchase()` request is used to complete the transaction on retu
 ## Sage Pay Shared Methods (Direct and Server)
 
 Note: these functions do not work for the `Form` API.
-These actions are performed through the "My Sage Pay" admin panel.
+These actions for `Sage Pay Form` must be performed manually through the "My Sage Pay"
+admin panel.
 
 * capture()
 * refund()

--- a/README.md
+++ b/README.md
@@ -622,6 +622,15 @@ $gateway = OmniPay::create('SagePay\Form')->initialize([
 
 The `encryptionKey` is generated in "My Sage Pay" when logged in as the administrator.
 
+Note that this gateway will assume all inout data (names, addresses etc.)
+are UTF-8 encoded.
+It will then recode the data to ISO8859-1 before encrypting it for the gateway,
+as the gateway strictly accepts ISO8859-1 only, regardless of what encoding is
+used to submit the form from the merchant site.
+If you do not want this conversion to happen, it can be disabled with this parameter:
+
+    'disableUtf8Decode' => true,
+
 The authorize must be given a `returnUrl` (the return URL on success, or on failure
 if no separate `failureUrl` is provided).
 
@@ -639,10 +648,11 @@ At the gateway, the user will authenticate or authorise their credit card,
 perform any 3D Secure actions that may be requested, then will return to the
 merchant site.
 
-To get the result, the transaction is "completed":
+To get the result details, the transaction is "completed":
 
 ```php
-// The result will in read and decrypted from the return URL query parameters:
+// The result will be read and decrypted from the return URL (or failure URL)
+// query parameters:
 
 $result = $gateway->completeAuthorize()->send();
 
@@ -650,6 +660,14 @@ $result->isSuccessful();
 $result->getTransactionReference();
 // etc.
 ```
+
+If you already have the encrypted response string, then it can be optionally
+passed in:
+
+    $result = $gateway->completeAuthorize(['crypt' => $crypt])->send();
+
+This should normally not be necessary, but is handy for testing or if the
+current page query parameters are not available in a particular architecture.
 
 ### Form Purchase
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Table of Contents
       * [Sage Pay Form Methods](#sage-pay-form-methods)
          * [Form Authorize](#form-authorize)
          * [Form Purchase](#form-purchase)
-      * [Sage Pay Shared Methods (for both Direct and Server)](#sage-pay-shared-methods-for-both-direct-and-server)
+      * [Sage Pay Shared Methods (Direct and Server)](#sage-pay-shared-methods-for-both-direct-and-server)
          * [Repeat Authorize/Purchase](#repeat-authorizepurchase)
          * [Capture](#capture)
          * [Delete Card](#delete-card)
@@ -655,7 +655,7 @@ $result->isSuccessful();
 This is the same as `authorize()`, but the `purchase()` request is used instead,
 and the `completePurchase()` request is used to complete the transaction on return.
 
-## Sage Pay Shared Methods (for both Direct and Server)
+## Sage Pay Shared Methods (Direct and Server)
 
 Note: these functions do not work for the `Form` API.
 These actions are performed through the "My Sage Pay" admin panel.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ Table of Contents
          * [Server Authorize/Purchase](#server-authorizepurchase)
          * [Server Create Card](#server-create-card)
          * [Server Notification Handler](#server-notification-handler)
-      * [Sage Pay Shared Methods (for both Direct and Server):](#sage-pay-shared-methods-for-both-direct-and-server)
+      * [Sage Pay Form Methods](#sage-pay-form-methods)
+         * [Form Authorize](#form-authorize)
+         * [Form Purchase](#form-purchase)
+      * [Sage Pay Shared Methods (for both Direct and Server)](#sage-pay-shared-methods-for-both-direct-and-server)
          * [Repeat Authorize/Purchase](#repeat-authorizepurchase)
          * [Capture](#capture)
          * [Delete Card](#delete-card)
@@ -69,6 +72,7 @@ The following gateways are provided by this package:
 
 * SagePay_Direct
 * SagePay_Server
+* SagePay_Form
 
 For general Omnipay usage instructions, please see the main
 [Omnipay](https://github.com/thephpleague/omnipay) repository.
@@ -586,7 +590,75 @@ The `$nextUrl` is where you want Sage Pay to send the user to next.
 It will often be the same URL whether the transaction was approved or not,
 since the result will be safely saved in the database.
 
-## Sage Pay Shared Methods (for both Direct and Server):
+## Sage Pay Form Methods
+
+Sage Pay Form requires neither a server-to-server back-channel nor
+IP-based security.
+The payment details are encrypted on the server before being sent to
+the gateway from the user's browser.
+The result is returned to the merchant site also through a client-side
+encrypted message.
+
+Capturing and voiding `Form` transactions is a manual process performed
+in the "My Sage Pay" administration panel.
+
+Supported functions are:
+
+* authorize()
+* purchase()
+
+### Form Authorize
+
+The authorization is intialized in a similar way to a `Server` payment,
+but with an `encryptionKey`:
+
+```php
+$gateway = OmniPay::create('SagePay\Form')->initialize([
+    'vendor' => 'vendorname',
+    'testMode' => true,
+    'encryptionKey' => 'abcdef1212345678',
+]);
+```
+
+The `encryptionKey` is generated in "My Sage Pay" when logged in as the administrator.
+
+The authorize must be given a `returnUrl` (the return URL on success, or on failure
+if no separate `failureUrl` is provided).
+
+```php
+$response = $gateway->authorize([
+    ...all the normal details...
+    //
+    'returnUrl' => 'https://example.com/success',
+    'failureUrl' => 'https://example.com/failure',
+]);
+```
+
+The `$response` will be a `POST` redirect, which will take use to the gateway.
+At the gateway, the user will authenticate or authorise their credit card,
+perform any 3D Secure actions that may be requested, then will return to the
+merchant site.
+
+To get the result, the transaction is "completed":
+
+```php
+// The result will in read and decrypted from the return URL query parameters:
+
+$result = $gateway->completeAuthorize()->send();
+
+$result->isSuccessful();
+// etc.
+```
+
+### Form Purchase
+
+This is the same as `authorize()`, but the `purchase()` request is used instead,
+and the `completePurchase()` request is used to complete the transaction on return.
+
+## Sage Pay Shared Methods (for both Direct and Server)
+
+Note: these functions do not work for the `Form` API.
+These actions are performed through the "My Sage Pay" admin panel.
 
 * capture()
 * refund()

--- a/src/AbstractGateway.php
+++ b/src/AbstractGateway.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Omnipay\SagePay;
+
+use Omnipay\Common\AbstractGateway as OmnipayAbstractGateway;
+use Omnipay\SagePay\Traits\GatewayParamsTrait;
+
+abstract class AbstractGateway extends OmnipayAbstractGateway implements ConstantsInterface
+{
+    use GatewayParamsTrait;
+
+    /**
+     * Examples for language: EN, DE and FR.
+     * Also supports a locale format.
+     */
+    public function getDefaultParameters()
+    {
+        return [
+            'vendor' => null,
+            'testMode' => false,
+            'referrerId' => null,
+            'language' => null,
+            'useOldBasketFormat' => false,
+            'exitOnResponse' => false,
+            'apply3DSecure' => null,
+            'useAuthenticate' => null,
+            'accountType' => null,
+        ];
+    }
+}

--- a/src/ConstantsInterface.php
+++ b/src/ConstantsInterface.php
@@ -116,6 +116,17 @@ interface ConstantsInterface
     const SERVICE_TOKEN             = 'directtoken';
     const SERVICE_DIRECT3D          = 'direct3dcallback';
 
+    /**
+     * 0 = Do not send either customer or vendor emails
+     * 1 = Send customer and vendor emails if addresses are provided
+     * 2 = Send vendor email but NOT the customer email
+     * If you do not supply this field, 1 is assumed and emails
+     * are sent if addresses are provided.
+     */
+    const SEND_EMAIL_NONE = '0';
+    const SEND_EMAIL_BOTH = '1';
+    const SEND_EMAIL_VENDOR = '2';
+
     //
     // Then the response constants.
     //

--- a/src/DirectGateway.php
+++ b/src/DirectGateway.php
@@ -2,8 +2,6 @@
 
 namespace Omnipay\SagePay;
 
-use Omnipay\Common\AbstractGateway;
-use Omnipay\SagePay\Traits\GatewayParamsTrait;
 use Omnipay\SagePay\Message\DirectAuthorizeRequest;
 use Omnipay\SagePay\Message\DirectCompleteAuthorizeRequest;
 use Omnipay\SagePay\Message\DirectPurchaseRequest;
@@ -20,34 +18,13 @@ use Omnipay\SagePay\Message\SharedTokenRemovalRequest;
  * Sage Pay Direct Gateway
  */
 
-class DirectGateway extends AbstractGateway implements ConstantsInterface
+class DirectGateway extends AbstractGateway
 {
-    use GatewayParamsTrait;
-
     // Gateway identification.
 
     public function getName()
     {
         return 'Sage Pay Direct';
-    }
-
-    /**
-     * Examples for language: EN, DE and FR.
-     * Also supports a locale format.
-     */
-    public function getDefaultParameters()
-    {
-        return [
-            'vendor' => null,
-            'testMode' => false,
-            'referrerId' => null,
-            'language' => null,
-            'useOldBasketFormat' => false,
-            'exitOnResponse' => false,
-            'apply3DSecure' => null,
-            'useAuthenticate' => null,
-            'accountType' => null,
-        ];
     }
 
     /**

--- a/src/FormGateway.php
+++ b/src/FormGateway.php
@@ -6,10 +6,6 @@ use Omnipay\SagePay\Message\Form\AuthorizeRequest;
 use Omnipay\SagePay\Message\Form\CompleteAuthorizeRequest;
 use Omnipay\SagePay\Message\Form\CompletePurchaseRequest;
 use Omnipay\SagePay\Message\Form\PurchaseRequest;
-//use Omnipay\SagePay\Message\ServerNotifyRequest;
-//use Omnipay\SagePay\Message\SharedTokenRemovalRequest;
-//use Omnipay\SagePay\Message\ServerTokenRegistrationRequest;
-//use Omnipay\SagePay\Message\ServerTokenRegistrationCompleteRequest;
 
 /**
  * Sage Pay Server Gateway

--- a/src/FormGateway.php
+++ b/src/FormGateway.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Omnipay\SagePay;
+
+// CHECKME: do we really need these?
+use Omnipay\SagePay\Message\ServerAuthorizeRequest;
+use Omnipay\SagePay\Message\ServerCompleteAuthorizeRequest;
+use Omnipay\SagePay\Message\ServerPurchaseRequest;
+use Omnipay\SagePay\Message\ServerNotifyRequest;
+use Omnipay\SagePay\Message\SharedTokenRemovalRequest;
+use Omnipay\SagePay\Message\ServerTokenRegistrationRequest;
+use Omnipay\SagePay\Message\ServerTokenRegistrationCompleteRequest;
+
+/**
+ * Sage Pay Server Gateway
+ */
+class FormGateway extends DirectGateway
+{
+    public function getName()
+    {
+        return 'Sage Pay Form';
+    }
+
+    /**
+     * Authorize a payment.
+     */
+    public function authorize(array $parameters = array())
+    {
+        return $this->createRequest(ServerAuthorizeRequest::class, $parameters);
+    }
+
+    /**
+     * Authorize and capture a payment.
+     */
+    public function purchase(array $parameters = array())
+    {
+        return $this->createRequest(ServerPurchaseRequest::class, $parameters);
+    }
+
+    /**
+     * Handle notification callback.
+     * Replaces completeAuthorize() and completePurchase()
+     */
+    public function acceptNotification(array $parameters = array())
+    {
+        return $this->createRequest(ServerNotifyRequest::class, $parameters);
+    }
+
+    /**
+     * Accept card details from a user and return a token, without any
+     * authorization against that card.
+     * i.e. standalone token creation.
+     * Omnipay standard function; alias for registerToken()
+     */
+    public function createCard(array $parameters = array())
+    {
+        return $this->registerToken($parameters);
+    }
+
+    /**
+     * Remove a card token from the account.
+     * Standard Omnipay function.
+     */
+    public function deleteCard(array $parameters = array())
+    {
+        return $this->createRequest(SharedTokenRemovalRequest::class, $parameters);
+    }
+
+    /**
+     * Accept card details from a user and return a token, without any
+     * authorization against that card.
+     * i.e. standalone token creation.
+     * Gateway-specific function.
+     */
+    public function registerToken(array $parameters = array())
+    {
+        return $this->createRequest(ServerTokenRegistrationRequest::class, $parameters);
+    }
+
+    /**
+     * Handle authorize notification callback.
+     * Please now use acceptNotification()
+     * @deprecated
+     */
+    public function completeAuthorize(array $parameters = array())
+    {
+        return $this->createRequest(ServerCompleteAuthorizeRequest::class, $parameters);
+    }
+
+    /**
+     * Handle purchase notification callback.
+     * Please now use acceptNotification()
+     * @deprecated
+     */
+    public function completePurchase(array $parameters = array())
+    {
+        return $this->completeAuthorize($parameters);
+    }
+}

--- a/src/FormGateway.php
+++ b/src/FormGateway.php
@@ -2,19 +2,19 @@
 
 namespace Omnipay\SagePay;
 
-// CHECKME: do we really need these?
-use Omnipay\SagePay\Message\ServerAuthorizeRequest;
-use Omnipay\SagePay\Message\ServerCompleteAuthorizeRequest;
-use Omnipay\SagePay\Message\ServerPurchaseRequest;
-use Omnipay\SagePay\Message\ServerNotifyRequest;
-use Omnipay\SagePay\Message\SharedTokenRemovalRequest;
-use Omnipay\SagePay\Message\ServerTokenRegistrationRequest;
-use Omnipay\SagePay\Message\ServerTokenRegistrationCompleteRequest;
+use Omnipay\SagePay\Message\Form\AuthorizeRequest;
+use Omnipay\SagePay\Message\Form\CompleteAuthorizeRequest;
+use Omnipay\SagePay\Message\Form\CompletePurchaseRequest;
+use Omnipay\SagePay\Message\Form\PurchaseRequest;
+//use Omnipay\SagePay\Message\ServerNotifyRequest;
+//use Omnipay\SagePay\Message\SharedTokenRemovalRequest;
+//use Omnipay\SagePay\Message\ServerTokenRegistrationRequest;
+//use Omnipay\SagePay\Message\ServerTokenRegistrationCompleteRequest;
 
 /**
  * Sage Pay Server Gateway
  */
-class FormGateway extends DirectGateway
+class FormGateway extends AbstractGateway
 {
     public function getName()
     {
@@ -26,7 +26,7 @@ class FormGateway extends DirectGateway
      */
     public function authorize(array $parameters = array())
     {
-        return $this->createRequest(ServerAuthorizeRequest::class, $parameters);
+        return $this->createRequest(AuthorizeRequest::class, $parameters);
     }
 
     /**
@@ -34,66 +34,22 @@ class FormGateway extends DirectGateway
      */
     public function purchase(array $parameters = array())
     {
-        return $this->createRequest(ServerPurchaseRequest::class, $parameters);
+        return $this->createRequest(PurchaseRequest::class, $parameters);
     }
 
     /**
-     * Handle notification callback.
-     * Replaces completeAuthorize() and completePurchase()
-     */
-    public function acceptNotification(array $parameters = array())
-    {
-        return $this->createRequest(ServerNotifyRequest::class, $parameters);
-    }
-
-    /**
-     * Accept card details from a user and return a token, without any
-     * authorization against that card.
-     * i.e. standalone token creation.
-     * Omnipay standard function; alias for registerToken()
-     */
-    public function createCard(array $parameters = array())
-    {
-        return $this->registerToken($parameters);
-    }
-
-    /**
-     * Remove a card token from the account.
-     * Standard Omnipay function.
-     */
-    public function deleteCard(array $parameters = array())
-    {
-        return $this->createRequest(SharedTokenRemovalRequest::class, $parameters);
-    }
-
-    /**
-     * Accept card details from a user and return a token, without any
-     * authorization against that card.
-     * i.e. standalone token creation.
-     * Gateway-specific function.
-     */
-    public function registerToken(array $parameters = array())
-    {
-        return $this->createRequest(ServerTokenRegistrationRequest::class, $parameters);
-    }
-
-    /**
-     * Handle authorize notification callback.
-     * Please now use acceptNotification()
-     * @deprecated
+     *
      */
     public function completeAuthorize(array $parameters = array())
     {
-        return $this->createRequest(ServerCompleteAuthorizeRequest::class, $parameters);
+        return $this->createRequest(CompleteAuthorizeRequest::class, $parameters);
     }
 
     /**
-     * Handle purchase notification callback.
-     * Please now use acceptNotification()
-     * @deprecated
+     *
      */
     public function completePurchase(array $parameters = array())
     {
-        return $this->completeAuthorize($parameters);
+        return $this->createRequest(CompletePurchaseRequest::class, $parameters);
     }
 }

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -423,6 +423,28 @@ abstract class AbstractRequest extends OmnipayAbstractRequest implements Constan
     }
 
     /**
+     * @return int static::ALLOW_GIFT_AID_YES or static::ALLOW_GIFT_AID_NO
+     */
+    public function getAllowGiftAid()
+    {
+        return $this->getParameter('allowGiftAid');
+    }
+
+    /**
+     * This flag allows the gift aid acceptance box to appear for this transaction
+     * on the payment page. This only appears if your vendor account is Gift Aid enabled.
+     *
+     * Values defined in static::ALLOW_GIFT_AID_* constant.
+     *
+     * @param bool|int $allowGiftAid value that casts to boolean
+     * @return $this
+     */
+    public function setAllowGiftAid($value)
+    {
+        $this->setParameter('allowGiftAid', $value);
+    }
+
+    /**
      * Return the Response object, initialised with the parsed response data.
      * @param  array $data The data parsed from the response gateway body.
      * @return Response

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -67,7 +67,7 @@ abstract class AbstractRequest extends OmnipayAbstractRequest implements Constan
      */
     public function getTxType()
     {
-        throw new InvalidRequestException('Transactino type not defined.');
+        throw new InvalidRequestException('Transaction type not defined.');
     }
 
     /**
@@ -98,6 +98,83 @@ abstract class AbstractRequest extends OmnipayAbstractRequest implements Constan
             list($language) = preg_split('/[-_]/', $language);
 
             $data['Language'] = $language;
+        }
+
+        return $data;
+    }
+
+    /**
+     * Get either the billing or the shipping address from
+     * the card object, mapped to Sage Pay field names.
+     *
+     * @param string $type 'Billing' or 'Shipping'
+     * @return array
+     */
+    protected function getAddressData($type = 'Billing')
+    {
+        $card = $this->getCard();
+
+        // Mapping is Sage Pay name => Omnipay Nname
+
+        $mapping = [
+            'Firstnames'    => 'FirstName',
+            'Surname'       => 'LastName',
+            'Address1'      => 'Address1',
+            'Address2'      => 'Address2',
+            'City'          => 'City',
+            'PostCode'      => 'Postcode',
+            'State'         => 'State',
+            'Country'       => 'Country',
+            'Phone'         => 'Phone',
+        ];
+
+        $data = [];
+
+        foreach ($mapping as $sagepayName => $omnipayName) {
+            $data[$sagepayName] = call_user_func([$card, 'get' . $type . $omnipayName]);
+        }
+
+        // The state must not be set for non-US countries.
+
+        if ($data['Country'] !== 'US') {
+            $data['State'] = '';
+        }
+
+        return $data;
+    }
+
+    /**
+     * Add the billing address details to the data.
+     *
+     * @param array $data
+     * @return array $data
+     */
+    protected function getBillingAddressData(array $data = [])
+    {
+        $address = $this->getAddressData('Billing');
+
+        foreach ($address as $name => $value) {
+            $data['Billing' . $name] = $value;
+        }
+
+        return $data;
+    }
+
+    /**
+     * Add the delivery (shipping) address details to the data.
+     * Use the Billing address if the billingForShipping option is set.
+     *
+     * @param array $data
+     * @return array $data
+     */
+    protected function getDeliveryAddressData(array $data = [])
+    {
+        $address = $this->getAddressData(
+            (bool)$this->getBillingForShipping() ? 'Billing' : 'Shipping'
+        );
+
+        foreach ($address as $name => $value) {
+            $data['Delivery' . $name] = $value;
         }
 
         return $data;
@@ -170,13 +247,11 @@ abstract class AbstractRequest extends OmnipayAbstractRequest implements Constan
      */
     public function getEndpoint()
     {
-        $service = $this->getService();
-
-        if ($this->getTestMode()) {
-            return $this->testEndpoint."/$service.vsp";
-        }
-
-        return $this->liveEndpoint."/$service.vsp";
+        return sprintf(
+            '%s/%s.vsp',
+            $this->getTestMode() ? $this->testEndpoint : $this->liveEndpoint,
+            $this->getService()
+        );
     }
 
     /**

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -114,7 +114,7 @@ abstract class AbstractRequest extends OmnipayAbstractRequest implements Constan
     {
         $card = $this->getCard();
 
-        // Mapping is Sage Pay name => Omnipay Nname
+        // Mapping is Sage Pay name => Omnipay Name
 
         $mapping = [
             'Firstnames'    => 'FirstName',

--- a/src/Message/DirectAuthorizeRequest.php
+++ b/src/Message/DirectAuthorizeRequest.php
@@ -42,7 +42,6 @@ class DirectAuthorizeRequest extends AbstractRequest
     protected function getBaseAuthorizeData()
     {
         $this->validate('amount', 'card', 'transactionId');
-        $card = $this->getCard();
 
         // Start with the authorisation and API version details.
         $data = $this->getBaseData();
@@ -63,36 +62,29 @@ class DirectAuthorizeRequest extends AbstractRequest
             $data['ReferrerID'] = $this->getReferrerId();
         }
 
-        // billing details
-        $data['BillingFirstnames'] = $card->getBillingFirstName();
-        $data['BillingSurname'] = $card->getBillingLastName();
-        $data['BillingAddress1'] = $card->getBillingAddress1();
-        $data['BillingAddress2'] = $card->getBillingAddress2();
-        $data['BillingCity'] = $card->getBillingCity();
-        $data['BillingPostCode'] = $card->getBillingPostcode();
-        $data['BillingState'] = ($card->getBillingCountry() === 'US' ? $card->getBillingState() : '');
-        $data['BillingCountry'] = $card->getBillingCountry();
-        $data['BillingPhone'] = $card->getBillingPhone();
+        // Billing details
 
-        // shipping details
-        $data['DeliveryFirstnames'] = $card->getShippingFirstName();
-        $data['DeliverySurname'] = $card->getShippingLastName();
-        $data['DeliveryAddress1'] = $card->getShippingAddress1();
-        $data['DeliveryAddress2'] = $card->getShippingAddress2();
-        $data['DeliveryCity'] = $card->getShippingCity();
-        $data['DeliveryPostCode'] = $card->getShippingPostcode();
-        $data['DeliveryState'] = ($card->getShippingCountry() === 'US' ? $card->getShippingState() : '');
-        $data['DeliveryCountry'] = $card->getShippingCountry();
-        $data['DeliveryPhone'] = $card->getShippingPhone();
-        $data['CustomerEMail'] = $card->getEmail();
+        $data = $this->getBillingAddressData($data);
+
+        // Shipping details
+
+        $data = $this->getDeliveryAddressData($data);
+
+        $card = $this->getCard();
+
+        if ($card->getEmail()) {
+            $data['CustomerEMail'] = $card->getEmail();
+        }
 
         if ((bool)$this->getUseOldBasketFormat()) {
             $basket = $this->getItemDataNonXML();
+
             if (!empty($basket)) {
                 $data['Basket'] = $basket;
             }
         } else {
             $basketXML = $this->getItemData();
+
             if (!empty($basketXML)) {
                 $data['BasketXML'] = $basketXML;
             }
@@ -101,7 +93,7 @@ class DirectAuthorizeRequest extends AbstractRequest
         $surchargeXml = $this->getSurchargeXml();
 
         if ($surchargeXml) {
-            $data['surchargeXml'] = $this->getSurchargeXml();
+            $data['surchargeXml'] = $surchargeXml;
         }
 
         return $data;

--- a/src/Message/DirectAuthorizeRequest.php
+++ b/src/Message/DirectAuthorizeRequest.php
@@ -47,6 +47,7 @@ class DirectAuthorizeRequest extends AbstractRequest
         $data = $this->getBaseData();
 
         $data['Description'] = $this->getDescription();
+
         // Money formatted as major unit decimal.
         $data['Amount'] = $this->getAmount();
         $data['Currency'] = $this->getCurrency();

--- a/src/Message/Form/AuthorizeRequest.php
+++ b/src/Message/Form/AuthorizeRequest.php
@@ -65,12 +65,14 @@ class AuthorizeRequest extends DirectAuthorizeRequest
     ];
 
     /**
-     * Add the Form-specific details to the base data.
+     * Get the full set of Sage Pay Form data, most of which is encrypted.
+     * TxType is only PAYMENT, DEFERRED or AUTHENTICATE
+     *
      * @reurn array
      */
     public function getData()
     {
-        $this->validate('currency', 'description', 'encryptionKey');
+        $this->validate('currency', 'description', 'encryptionKey', 'returnUrl');
 
         // The test mode is included to determine the redirect URL.
 
@@ -85,6 +87,7 @@ class AuthorizeRequest extends DirectAuthorizeRequest
 
     /**
      * @return array the data required to be encoded into the form crypt field.
+     * @throws InvalidRequestException if any mandatory fields are missing
      */
     public function getCryptData()
     {
@@ -97,7 +100,7 @@ class AuthorizeRequest extends DirectAuthorizeRequest
             $data = $this->getTokenData($data);
         }
 
-        // Some parameers specific to Sage Pay Form..
+        // Some [optional] parameters specific to Sage Pay Form..
 
         if ($this->getCustomerName() !== null) {
             $data['CustomerName'] = $this->getCustomerName();
@@ -130,8 +133,6 @@ class AuthorizeRequest extends DirectAuthorizeRequest
 
             $data['SendEmail'] = $this->getSendEmail();
         }
-
-        // TxType: only PAYMENT, DEFERRED or AUTHENTICATE
 
         $data['SuccessURL'] = $this->getReturnUrl();
         $data['FailureURL'] = $this->getFailureUrl() ?: $this->getReturnUrl();

--- a/src/Message/Form/AuthorizeRequest.php
+++ b/src/Message/Form/AuthorizeRequest.php
@@ -189,18 +189,26 @@ class AuthorizeRequest extends DirectAuthorizeRequest
 
         // Build the data in a query string.
 
-        // CHECKME: what happens with UTF-8 data? Do we need to convert
-        // any special characters not in the correct ranges?
-        // What about options for URL encoding of other characters?
+        // The encrypted data MUST be ISO8859-1 regardless of what encoding
+        // is used to submit the form, because that is how the gateway treats
+        // the data internally.
+        // This package assumes input data will be UTF-8 by default, and will
+        // comvert it accordingly. This can be disabled if the data is already
+        // ISO8859-1.
+        // For the Server and Direct gateway methods, the POST encoding type
+        // will tell the gateway how to interpret the character encoding, and
+        // the gateway will do any encoding conversions necessary.
 
         // We cannot use http_build_query() because the gateway does
         // not decode the string as any standard encoded query string.
         // We just join the names and values with "=" and "&" and the
         // gateway somehow decodes ambiguous strings.
 
+        $disableUtf8Decode = (bool)$this->getDisableUtf8Decode();
+
         $query = [];
         foreach ($data as $name => $value) {
-            $query[] = $name . '=' . $value;
+            $query[] = $name . '=' . ($disableUtf8Decode ? $value : utf8_decode($value));
         }
         $query = implode('&', $query);
 

--- a/src/Message/Form/AuthorizeRequest.php
+++ b/src/Message/Form/AuthorizeRequest.php
@@ -97,7 +97,39 @@ class AuthorizeRequest extends DirectAuthorizeRequest
             $data = $this->getTokenData($data);
         }
 
-        // TODO: lots more fields in here.
+        // Some parameers specific to Sage Pay Form..
+
+        if ($this->getCustomerName() !== null) {
+            $data['CustomerName'] = $this->getCustomerName();
+        }
+
+        if ($this->getVendorEmail() !== null) {
+            $data['VendorEmail'] = $this->getVendorEmail();
+        }
+
+        if ($this->getEmailMessage() !== null) {
+            $data['EmailMessage'] = $this->getEmailMessage();
+        }
+
+        if ($this->getAllowGiftAid() !== null) {
+            $data['AllowGiftAid'] = (bool)$this->getAllowGiftAid()
+                ? static::ALLOW_GIFT_AID_YES : static::ALLOW_GIFT_AID_NO;
+        }
+
+        if ($this->getWebsite() !== null) {
+            $data['Website'] = $this->getWebsite();
+        }
+
+        if ($sendEmail = $this->getSendEmail() !== null) {
+            if ($sendEmail != static::SEND_EMAIL_NONE
+                && $sendEmail != static::SEND_EMAIL_BOTH
+                && $sendEmail != static::SEND_EMAIL_VENDOR
+            ) {
+                $sendEmail = static::SEND_EMAIL_BOTH;
+            }
+
+            $data['SendEmail'] = $this->getSendEmail();
+        }
 
         // TxType: only PAYMENT, DEFERRED or AUTHENTICATE
 
@@ -125,6 +157,8 @@ class AuthorizeRequest extends DirectAuthorizeRequest
 
         // Two conditional checks on the "state" fields.
         // We don't check if it is a valid two-character state code.
+        // Maybe this can be moved to the construction of the addresses
+        // in AbstractRequest.
 
         if ($data['BillingCountry'] === 'US' && empty($data['BillingState'])
             || $data['DeliveryCountry'] === 'US' && empty($data['DeliveryState'])
@@ -217,5 +251,92 @@ class AuthorizeRequest extends DirectAuthorizeRequest
     public function getFailureUrl()
     {
         return $this->getParameter('failureUrl');
+    }
+
+    /**
+     * @param string|null $value Customer's name will be included in the confirmation emails
+     * @return $this
+     */
+    public function setCustomerName($value)
+    {
+        return $this->setParameter('customerName', $value);
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getCustomerName()
+    {
+        return $this->getParameter('customerName');
+    }
+
+    /**
+     * @param string|null $value An email will be sent to this address when each transaction completes
+     * @return $this
+     */
+    public function setVendorEmail($value)
+    {
+        return $this->setParameter('vendorEmail', $value);
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getVendorEmail()
+    {
+        return $this->getParameter('vendorEmail');
+    }
+
+    /**
+     * @param string|null $value 0, 1, or 2, see 
+     * @return $this
+     */
+    public function setSendEmail($value)
+    {
+        return $this->setParameter('sendEmail', $value);
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getSendEmail()
+    {
+        return $this->getParameter('sendEmail');
+    }
+
+    /**
+     * This message can be formatted using HTML, up to 1000 bytes.
+     *
+     * @param string|null $value A message to the customer, inserted into successful emails
+     * @return $this
+     */
+    public function setEmailMessage($value)
+    {
+        return $this->setParameter('EmailMessage', $value);
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getEmailMessage()
+    {
+        return $this->getParameter('EmailMessage');
+    }
+
+    /**
+     * @param string|null $value
+     * @return $this
+     */
+    public function setWebsite($value)
+    {
+        return $this->setParameter('website', $value);
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getWebsite()
+    {
+        return $this->getParameter('website');
     }
 }

--- a/src/Message/Form/AuthorizeRequest.php
+++ b/src/Message/Form/AuthorizeRequest.php
@@ -65,6 +65,25 @@ class AuthorizeRequest extends DirectAuthorizeRequest
     ];
 
     /**
+     * Add the Form-specific details to the base data.
+     * @reurn array
+     */
+    public function getData()
+    {
+        $this->validate('currency', 'description', 'encryptionKey');
+
+        // The test mode is included to determine the redirect URL.
+
+        return [
+            'VPSProtocol' => $this->VPSProtocol,
+            'TxType' => $this->getTxType(),
+            'Vendor' => $this->getVendor(),
+            'Crypt' => $this->generateCrypt($this->getCryptData()),
+            'TestMode' => $this->getTestMode(),
+        ];
+    }
+
+    /**
      * @return array the data required to be encoded into the form crypt field.
      */
     public function getCryptData()
@@ -107,8 +126,8 @@ class AuthorizeRequest extends DirectAuthorizeRequest
         // Two conditional checks on the "state" fields.
         // We don't check if it is a valid two-character state code.
 
-        if ($data['BillingCountry'] === 'US' && empty ($data['BillingState'])
-            || $data['DeliveryCountry'] === 'US' && empty ($data['DeliveryState'])
+        if ($data['BillingCountry'] === 'US' && empty($data['BillingState'])
+            || $data['DeliveryCountry'] === 'US' && empty($data['DeliveryState'])
         ) {
             throw new InvalidRequestException(
                 'Missing state code for billing or shipping address'
@@ -116,25 +135,6 @@ class AuthorizeRequest extends DirectAuthorizeRequest
         }
 
         return $data;
-    }
-
-    /**
-     * Add the Form-specific details to the base data.
-     * @reurn array
-     */
-    public function getData()
-    {
-        $this->validate('currency', 'description');
-
-        // The test mode is included to determine the redirect URL.
-
-        return [
-            'VPSProtocol' => $this->VPSProtocol,
-            'TxType' => $this->getTxType(),
-            'Vendor' => $this->getVendor(),
-            'Crypt' => $this->generateCrypt($this->getCryptData()),
-            'TestMode' => $this->getTestMode(),
-        ];
     }
 
     /**

--- a/src/Message/Form/AuthorizeRequest.php
+++ b/src/Message/Form/AuthorizeRequest.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace Omnipay\SagePay\Message\Form;
+
+/**
+ * Sage Pay Form Authorize Request.
+ */
+
+use Omnipay\SagePay\Message\DirectAuthorizeRequest;
+
+class AuthorizeRequest extends DirectAuthorizeRequest
+{
+    /**
+     * Fields accepted by the Form API.
+     * "true" fields are mandatory.
+     */
+    protected $validFields = [
+        'VendorTxCode' => true,
+        'Amount' => true,
+        'Currency' => true,
+        'Description' => true,
+        'SuccessURL' => true,
+        'FailureURL' => true,
+        'CustomerName' => false,
+        'CustomerEMail' => false,
+        'VendorEMail' => false,
+        'SendEMail' => false,
+        'EmailMessage' => false,
+        'BillingSurname' => true,
+        'BillingFirstnames' => true,
+        'BillingAddress1' => true,
+        'BillingAddress2' => false,
+        'BillingCity' => true,
+        'BillingPostCode' => true,
+        'BillingCountry' => true,
+        'BillingState' => false,
+        'BillingPhone' => false,
+        'DeliverySurname' => true,
+        'DeliveryFirstnames' => true,
+        'DeliveryAddress1' => true,
+        'DeliveryAddress2' => false,
+        'DeliveryCity' => true,
+        'DeliveryPostCode' => true,
+        'DeliveryCountry' => true,
+        'DeliveryState' => false,
+        'DeliveryPhone' => false,
+        'Basket' => false,
+        'AllowGiftAid' => false,
+        'ApplyAVSCV2' => false,
+        'Apply3DSecure' => false,
+        'BillingAgreement' => false,
+        'BasketXML' => false,
+        'CustomerXML' => false,
+        'SurchargeXML' => false,
+        'VendorData' => false,
+        'ReferrerID' => false,
+        'Language' => false,
+        'Website' => false,
+        'FIRecipientAcctNumber' => false,
+        'FIRecipientSurname' => false,
+        'FIRecipientPostcode' => false,
+        'FIRecipientDoB' => false,
+    ];
+
+    /**
+     * @return array the data required to be encoded into the form crypt field.
+     */
+    public function getCryptData()
+    {
+        $data = $this->getBaseAuthorizeData();
+
+        // CHECKME: are tokens supported?
+
+        if ($this->getToken() || $this->getCardReference()) {
+            // If using a token, then set that data.
+            $data = $this->getTokenData($data);
+        }
+
+        // TODO: lots more fields in here.
+
+        // TxType: only PAYMENT, DEFERRED or AUTHENTICATE
+
+        $data['SuccessURL'] = $this->getReturnUrl();
+        $data['FailureURL'] = $this->getFailureUrl() ?: $this->getReturnUrl();
+
+        // Filter out any fields that are not accepted by the form API.
+        // Unexpected fields throw a general 5080 error which is very
+        // difficult to debug.
+
+        $data = array_intersect_key($data, $this->validFields);
+
+        // TODO: throw exception if any mandatory fields are missing.
+        // We need to catch it here before sending the user to an
+        // unexpected on the gateway site.
+
+        // ...
+
+        return $data;
+    }
+
+    /**
+     * Add the Form-specific details to the base data.
+     */
+    public function getData()
+    {
+        return [
+            'VPSProtocol' => $this->VPSProtocol,
+            'TxType' => $this->getTxType(),
+            'Vendor' => $this->getVendor(),
+            'Crypt' => $this->generateCrypt($this->getCryptData()),
+            'TestMode' => $this->getTestMode(),
+        ];
+    }
+
+    /**
+     * Generate the crypt field from the source data.
+     */
+    public function generateCrypt(array $data)
+    {
+        // No data values should be null.
+
+        array_walk($data, function (&$value) {
+            if (! isset($value)) {
+                $value = '';
+            }
+        });
+
+        // Build the data in a query string.
+
+        // CHECKME: what happens with UTF-8 data? Do we need to convert
+        // any special characters not in the correct ranges?
+        // What about options for URL encoding of other characters?
+
+        // We cannot use http_build_query() because the gateway does
+        // not decode the string as any standard encoded query string.
+        // We just join the names and values with "=" and "&" and the
+        // gateway somehow decodes ambiguous strings.
+
+        $query = [];
+        foreach ($data as $name => $value) {
+            $query[] = $name . '=' . $value;
+        }
+        $query = implode('&', $query);
+
+        // Encrypted using AES(block size 128-bit) in CBC mode with PKCS#5 padding.
+
+        // AES encryption, CBC blocking with PKCS5 padding then HEX encoding.
+
+        $key = $this->getEncryptionKey();
+
+        // Normally IV (paramert 5, initialization vector) would be a kind of salt.
+        // That is more relevant when encrypting user details where multiple users
+        // could have identical passwords. But this is a one-off transport of a message
+        // that will always be unique, so no variable IV is needed.
+
+        $crypt = openssl_encrypt($query, 'aes-128-cbc', $key, OPENSSL_RAW_DATA, $key);
+
+        return '@' . strtoupper(bin2hex($crypt));
+    }
+
+    public function sendData($data)
+    {
+        // The result is always going to be a POST redirect.
+
+        return $this->createResponse($data);
+    }
+
+    /**
+     * Return the Response object, initialised with the parsed response data.
+     * @param  array $data The data parsed from the response gateway body.
+     * @return Response
+     */
+    protected function createResponse($data)
+    {
+        return $this->response = new Response($this, $data);
+    }
+
+    /**
+     * @param string|null $value The URL the Form gateway will return to on cancel or error.
+     * @return $this
+     */
+    public function setFailureUrl($value)
+    {
+        return $this->setParameter('failureUrl', $value);
+    }
+
+    /**
+     * @return string|null The URL the Form gateway will return to on cancel or error.
+     */
+    public function getFailureUrl()
+    {
+        return $this->getParameter('failureUrl');
+    }
+}

--- a/src/Message/Form/AuthorizeRequest.php
+++ b/src/Message/Form/AuthorizeRequest.php
@@ -288,7 +288,7 @@ class AuthorizeRequest extends DirectAuthorizeRequest
     }
 
     /**
-     * @param string|null $value 0, 1, or 2, see 
+     * @param string|null $value 0, 1, or 2, see constants SEND_EMAIL_*
      * @return $this
      */
     public function setSendEmail($value)

--- a/src/Message/Form/CompleteAuthorizeRequest.php
+++ b/src/Message/Form/CompleteAuthorizeRequest.php
@@ -28,7 +28,7 @@ class CompleteAuthorizeRequest extends AbstractRequest
      */
     public function getData()
     {
-        $crypt = $this->httpRequest->query->get('crypt');
+        $crypt = $this->getCrypt() ?: $this->httpRequest->query->get('crypt');
 
         // Remove the leading '@' and decrypt.
 
@@ -46,10 +46,20 @@ class CompleteAuthorizeRequest extends AbstractRequest
     }
 
     /**
-     * Nothing to send - we have the result data in the server request.
+     * Nothing to send to gateway - we have the result data in the server request.
      */
     public function sendData($data)
     {
         return $this->response = new Response($this, $data);
+    }
+
+    public function getCrypt()
+    {
+        return $this->getParameter('cryptx');
+    }
+
+    public function setCrypt($value)
+    {
+        return $this->setParameter('cryptx', $value);
     }
 }

--- a/src/Message/Form/CompleteAuthorizeRequest.php
+++ b/src/Message/Form/CompleteAuthorizeRequest.php
@@ -50,14 +50,25 @@ class CompleteAuthorizeRequest extends AbstractRequest
      */
     public function sendData($data)
     {
+        // The Response in the current namespace conflicts with
+        // the Response in the namespace one level down, but only
+        // for PHP 5.6. This alias works around it.
+
         return $this->response = new GenericResponse($this, $data);
     }
 
+    /**
+     * @return string The crypt set as an override for the query parameter.
+     */
     public function getCrypt()
     {
         return $this->getParameter('cryptx');
     }
 
+    /**
+     * @param string $value If set, then used in preference to the current query parameter.
+     * @return $this
+     */
     public function setCrypt($value)
     {
         return $this->setParameter('cryptx', $value);

--- a/src/Message/Form/CompleteAuthorizeRequest.php
+++ b/src/Message/Form/CompleteAuthorizeRequest.php
@@ -7,7 +7,7 @@ namespace Omnipay\SagePay\Message\Form;
  */
 
 use Omnipay\SagePay\Message\AbstractRequest;
-use Omnipay\SagePay\Message\Response;
+use Omnipay\SagePay\Message\Response as GenericResponse;
 
 class CompleteAuthorizeRequest extends AbstractRequest
 {
@@ -50,7 +50,7 @@ class CompleteAuthorizeRequest extends AbstractRequest
      */
     public function sendData($data)
     {
-        return $this->response = new Response($this, $data);
+        return $this->response = new GenericResponse($this, $data);
     }
 
     public function getCrypt()

--- a/src/Message/Form/CompleteAuthorizeRequest.php
+++ b/src/Message/Form/CompleteAuthorizeRequest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Omnipay\SagePay\Message\Form;
+
+/**
+ * Sage Pay Form Complete Authorize Response.
+ */
+
+use Omnipay\SagePay\Message\AbstractRequest;
+use Omnipay\SagePay\Message\Response;
+
+class CompleteAuthorizeRequest extends AbstractRequest
+{
+    /**
+     * @return string the transaction type
+     */
+    public function getTxType()
+    {
+        if ($this->getUseAuthenticate()) {
+            return static::TXTYPE_AUTHORISE;
+        } else {
+            return static::TXTYPE_RELEASE;
+        }
+    }
+
+    /**
+     * Data will be encrypted as a query parameter.
+     */
+    public function getData()
+    {
+        $crypt = $this->httpRequest->query->get('crypt');
+
+        // Remove the leading '@' and decrypt.
+
+        $query = openssl_decrypt(
+            hex2bin(substr($crypt, 1)),
+            'aes-128-cbc',
+            $this->getEncryptionKey(),
+            OPENSSL_RAW_DATA,
+            $this->getEncryptionKey()
+        );
+
+        parse_str($query, $data);
+
+        return($data);
+    }
+
+    /**
+     * Nothing to send - we have the result data in the server request.
+     */
+    public function sendData($data)
+    {
+        return $this->response = new Response($this, $data);
+    }
+}

--- a/src/Message/Form/CompletePurchaseRequest.php
+++ b/src/Message/Form/CompletePurchaseRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Omnipay\SagePay\Message\Form;
+
+/**
+ * Sage Pay Form Complete Purchase Response.
+ */
+
+class CompletePurchaseRequest extends CompleteAuthorizeRequest
+{
+    /**
+     * @return string the transaction type
+     */
+    public function getTxType()
+    {
+        return static::TXTYPE_PAYMENT;
+    }
+}

--- a/src/Message/Form/PurchaseRequest.php
+++ b/src/Message/Form/PurchaseRequest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Omnipay\SagePay\Message\Form;
+
+/**
+ * Sage Pay Direct Purchase Request
+ */
+class PurchaseRequest extends AuthorizeRequest
+{
+    public function getTxType()
+    {
+        return static::TXTYPE_PAYMENT;
+    }
+}

--- a/src/Message/Form/Response.php
+++ b/src/Message/Form/Response.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Omnipay\SagePay\Message\Form;
+
+/**
+ * Sage Pay Form Authorize/Purchase Response (form POST redirect).
+ */
+
+use Omnipay\Common\Message\AbstractResponse;
+use Omnipay\Common\Message\RedirectResponseInterface;
+use Omnipay\SagePay\ConstantsInterface;
+
+class Response extends AbstractResponse implements RedirectResponseInterface, ConstantsInterface
+{
+    /**
+     * @var string Endpoint base URLs.
+     */
+    protected $liveEndpoint = 'https://live.sagepay.com/gateway/service/vspform-register.vsp';
+    protected $testEndpoint = 'https://test.sagepay.com/gateway/service/vspform-register.vsp';
+
+    /**
+     * Always a redirect, so not yet successful.
+     */
+    public function isSuccessful()
+    {
+        return false;
+    }
+
+    public function isRedirect()
+    {
+        return true;
+    }
+
+    public function getRedirectMethod()
+    {
+        return 'POST';
+    }
+
+    public function getRedirectData()
+    {
+        return array_intersect_key(
+            $this->getData(),
+            array_flip([
+                'VPSProtocol',
+                'TxType',
+                'Vendor',
+                'Crypt',
+            ])
+        );
+    }
+
+    /**
+     * @return string URL to 3D Secure endpoint.
+     */
+    public function getRedirectUrl()
+    {
+        if ($this->getTestMode()) {
+            return $this->testEndpoint;
+        }
+
+        return $this->liveEndpoint;
+    }
+
+    public function getTestMode()
+    {
+        $data =  $this->getData();
+
+        return !empty($data['TestMode']);
+    }
+}

--- a/src/Message/Form/Response.php
+++ b/src/Message/Form/Response.php
@@ -20,24 +20,36 @@ class Response extends AbstractResponse implements RedirectResponseInterface, Co
 
     /**
      * Always a redirect, so not yet successful.
+     * @return @inherit
      */
     public function isSuccessful()
     {
         return false;
     }
 
+    /**
+     * @return @inherit
+     */
     public function isRedirect()
     {
         return true;
     }
 
+    /**
+     * @return @inherit
+     */
     public function getRedirectMethod()
     {
         return 'POST';
     }
 
+    /**
+     * @return @inherit
+     */
     public function getRedirectData()
     {
+        // Pull out just these four fields from the data supplied.
+
         return array_intersect_key(
             $this->getData(),
             array_flip([
@@ -61,6 +73,9 @@ class Response extends AbstractResponse implements RedirectResponseInterface, Co
         return $this->liveEndpoint;
     }
 
+    /**
+     * @return @inherit
+     */
     public function getTestMode()
     {
         $data =  $this->getData();

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -43,7 +43,7 @@ class Response extends AbstractResponse implements RedirectResponseInterface, Co
     {
         $reference = [];
 
-        foreach (['SecurityKey', 'TxAuthNo', 'VPSTxId'] as $key) {
+        foreach (['SecurityKey', 'TxAuthNo', 'VPSTxId', 'VendorTxCode'] as $key) {
             $value = $this->getDataItem($key);
 
             if ($value !== null) {
@@ -57,9 +57,12 @@ class Response extends AbstractResponse implements RedirectResponseInterface, Co
             return;
         }
 
-        // Remaining transaction details supplied by the merchant site.
+        // Remaining transaction details supplied by the merchant site
+        // if not already in the response (it will be for Sage Pay Form).
 
-        $reference['VendorTxCode'] = $this->getRequest()->getTransactionId();
+        if (! array_key_exists('VendorTxCode', $reference)) {
+            $reference['VendorTxCode'] = $this->getRequest()->getTransactionId();
+        }
 
         ksort($reference);
 

--- a/src/Message/ServerAuthorizeRequest.php
+++ b/src/Message/ServerAuthorizeRequest.php
@@ -63,28 +63,6 @@ class ServerAuthorizeRequest extends DirectAuthorizeRequest
     }
 
     /**
-     * @return int static::ALLOW_GIFT_AID_YES or static::ALLOW_GIFT_AID_NO
-     */
-    public function getAllowGiftAid()
-    {
-        return $this->getParameter('allowGiftAid');
-    }
-
-    /**
-     * This flag allows the gift aid acceptance box to appear for this transaction
-     * on the payment page. This only appears if your vendor account is Gift Aid enabled.
-     *
-     * Values defined in static::ALLOW_GIFT_AID_* constant.
-     *
-     * @param bool|int $allowGiftAid value that casts to boolean
-     * @return $this
-     */
-    public function setAllowGiftAid($value)
-    {
-        $this->setParameter('allowGiftAid', $value);
-    }
-
-    /**
      * The Server API allows Giftaid to be selected by the user.
      * This turns the feature on and off.
      * CHECKME: any reason this can't be moved into getData()?

--- a/src/Message/Shared/FetchTransaction.php
+++ b/src/Message/Shared/FetchTransaction.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Omnipay\SagePay\Message\Shared;
+
+/**
+ * Sage Pay fetch a transaction.
+ * Reporting command: getTransactionDetail
+ */
+
+use Omnipay\SagePay\Message\AbstractRequest;
+
+class FetchTransaction extends AbstractRequest
+{
+    // TODO: this is an XML interface completely different to the payments APIs.
+}

--- a/src/Message/SharedRepeatAuthorizeRequest.php
+++ b/src/Message/SharedRepeatAuthorizeRequest.php
@@ -69,18 +69,9 @@ class SharedRepeatAuthorizeRequest extends AbstractRequest
         $card = $this->getCard();
 
         // If a card is provided, then assume all billing details are being updated.
-        // TODO: move this construct to a separate method, as it is used several times.
 
         if ($card) {
-            $data['BillingFirstnames'] = $card->getBillingFirstName();
-            $data['BillingSurname'] = $card->getBillingLastName();
-            $data['BillingAddress1'] = $card->getBillingAddress1();
-            $data['BillingAddress2'] = $card->getBillingAddress2();
-            $data['BillingCity'] = $card->getBillingCity();
-            $data['BillingPostCode'] = $card->getBillingPostcode();
-            $data['BillingState'] = $card->getBillingCountry() === 'US' ? $card->getBillingState() : '';
-            $data['BillingCountry'] = $card->getBillingCountry();
-            $data['BillingPhone'] = $card->getBillingPhone();
+            $data = $this->getBillingAddressData($data);
 
             // If the customer is present, then the CV2 can be supplied again for extra security.
 

--- a/src/Traits/GatewayParamsTrait.php
+++ b/src/Traits/GatewayParamsTrait.php
@@ -237,4 +237,24 @@ trait GatewayParamsTrait
     {
         return $this->setParameter('billingForShipping', $value);
     }
+
+    /**
+     * @return mixed
+     */
+    public function getDisableUtf8Decode()
+    {
+        return $this->getParameter('disableUtf8Decode');
+    }
+
+    /**
+     * The Form API will convert all input data from an assumed UTF-8
+     * encoding to ISO8859-1 by default, unless disabled here.
+     *
+     * @param mixed $value Will be evaluated as boolean.
+     * @return $this
+     */
+    public function setDisableUtf8Decode($value)
+    {
+        return $this->setParameter('disableUtf8Decode', $value);
+    }
 }

--- a/src/Traits/GatewayParamsTrait.php
+++ b/src/Traits/GatewayParamsTrait.php
@@ -201,4 +201,40 @@ trait GatewayParamsTrait
     {
         return $this->setParameter('accountType', $value);
     }
+
+    /**
+     * @return string|null Encryption key for Sage Pay Form
+     */
+    public function getEncryptionKey()
+    {
+        return $this->getParameter('encryptionKey');
+    }
+
+    /**
+     * @param string $value Encryption key for Sage Pay Form; aka form password
+     * @return $this
+     */
+    public function setEncryptionKey($value)
+    {
+        return $this->setParameter('encryptionKey', $value);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getBillingForShipping()
+    {
+        return $this->getParameter('billingForShipping');
+    }
+
+    /**
+     * Set to force the billing address to be used as the shipping address.
+     *
+     * @param mixed $value Will be evaluated as boolean.
+     * @return $this
+     */
+    public function setBillingForShipping($value)
+    {
+        return $this->setParameter('billingForShipping', $value);
+    }
 }

--- a/tests/FormGatewayTest.php
+++ b/tests/FormGatewayTest.php
@@ -17,6 +17,7 @@ class FormGatewayTest extends GatewayTestCase
             $this->getHttpRequest()
         );
         $this->gateway->setVendor('example');
+        $this->gateway->setCurrency('EUR');
 
         $this->purchaseOptions = array(
             'amount' => '10.00',
@@ -24,6 +25,7 @@ class FormGatewayTest extends GatewayTestCase
             'card' => $this->getValidCard(),
             'returnUrl' => 'https://www.example.com/return',
             'encryptionKey' => '12345678abcdeabc',
+            'description' => 'Some message',
         );
 
         $this->captureOptions = array(

--- a/tests/FormGatewayTest.php
+++ b/tests/FormGatewayTest.php
@@ -17,55 +17,26 @@ class FormGatewayTest extends GatewayTestCase
             $this->getHttpRequest()
         );
         $this->gateway->setVendor('example');
-        $this->gateway->setCurrency('EUR');
 
-        $this->purchaseOptions = array(
+        $this->purchaseOptions = [
             'amount' => '10.00',
+            'currency' => 'EUR',
             'transactionId' => '123',
             'card' => $this->getValidCard(),
             'returnUrl' => 'https://www.example.com/return',
             'encryptionKey' => '12345678abcdeabc',
             'description' => 'Some message',
-        );
+        ];
 
-        $this->captureOptions = array(
+        $this->captureOptions = [
             'amount' => '10.00',
             'transactionId' => '123',
             'transactionReference' => '{"SecurityKey":"JEUPDN1N7E","TxAuthNo":"4255","VPSTxId":"{F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2}","VendorTxCode":"438791"}',
-        );
+        ];
 
-        $this->completePurchaseOptions = array(
-            'amount' => '10.00',
-            'transactionId' => '123',
-            'transactionReference' => '{"SecurityKey":"JEUPDN1N7E","TxAuthNo":"4255","VPSTxId":"{F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2}","VendorTxCode":"438791"}',
-            'encryptionKey' => '12345678abcdeabc',
-        );
-
-        $this->voidOptions = array(
-            'transactionId' => '123',
-            'transactionReference' => '{"SecurityKey":"JEUPDN1N7E","TxAuthNo":"4255","VPSTxId":"{F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2}","VendorTxCode":"438791"}',
-        );
-
-        $this->abortOptions = array(
-            'transactionId' => '123',
-            'transactionReference' => '{"SecurityKey":"JEUPDN1N7E","TxAuthNo":"4255","VPSTxId":"{F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2}","VendorTxCode":"438791"}',
-        );
-
-        $this->refundOptions = array(
-            'amount' => '10.00',
-            'currency' => 'GBP',
-            'transactionId' => '123',
-            'transactionReference' => '{"SecurityKey":"JEUPDN1N7E","TxAuthNo":"4255","VPSTxId":"{F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2}","VendorTxCode":"438791"}',
-            'description' => 'Some kind of refund',
-        );
-
-        $this->repeatOptions = array(
-            'amount' => '10.00',
-            'currency' => 'GBP',
-            'transactionId' => '123',
-            'transactionReference' => '{"SecurityKey":"JEUPDN1N7E","TxAuthNo":"4255","VPSTxId":"{F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2}","VendorTxCode":"438791"}',
-            'description' => 'Some kind of repeat payment',
-        );
+        $this->completePurchaseOptions = [
+            'encryptionKey' => '2f52208a25a1facf',
+        ];
     }
 
     public function testInheritsDirectGateway()
@@ -75,64 +46,139 @@ class FormGatewayTest extends GatewayTestCase
 
     public function testAuthorizeSuccess()
     {
-        $this->setMockHttpResponse('ServerPurchaseSuccess.txt');
-
         $response = $this->gateway->authorize($this->purchaseOptions)->send();
 
         $this->assertFalse($response->isSuccessful());
         $this->assertTrue($response->isRedirect());
 
-        // TODO: look at the redirect data.
-    }
-
-    public function testAuthorizeFailure()
-    {
-        $this->setMockHttpResponse('ServerPurchaseFailure.txt');
-
-        $response = $this->gateway->authorize($this->purchaseOptions)->send();
-
-        $this->assertFalse($response->isSuccessful());
-        $this->assertTrue($response->isRedirect());
-    }
-/*
-    public function testCompleteAuthorizeSuccess()
-    {
-        $this->getHttpRequest()->request->replace(
-            array(
-                'Status' => 'OK',
-                'TxAuthNo' => 'b',
-                'AVSCV2' => 'c',
-                'AddressResult' => 'd',
-                'PostCodeResult' => 'e',
-                'CV2Result' => 'f',
-                'GiftAid' => 'g',
-                '3DSecureStatus' => 'h',
-                'CAVV' => 'i',
-                'AddressStatus' => 'j',
-                'PayerStatus' => 'k',
-                'CardType' => 'l',
-                'Last4Digits' => 'm',
-                // New fields for protocol v3.00
-                'DeclineCode' => '00',
-                'ExpiryDate' => '0722',
-                'BankAuthCode' => '999777',
-                'VPSSignature' => md5(
-                    '{F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2}'
-                    . '438791' . 'OK' . 'bexamplecJEUPDN1N7Edefghijklm' . '00' . '0722' . '999777'
-                ),
-            )
+        $this->assertSame(
+            [
+                'VPSProtocol' => '3.00',
+                'TxType' => 'DEFERRED',
+                'Vendor' => 'example',
+                'Crypt' => '@BE1508740B97BEC235E9E8474168E3D4DEAD71C1395CDAC1A24F4784A71135AE797F5451F48EB2EAF5669EB3F6953F466FC3A03E5815E607C4DD18C03D7BDD61D176DB4DF131DC0F02DFC5145FFBA841651641BDAA405E72F4EF8849C2B2FD1F08763E3E66EAF3C479429A92014C7B8316F3B446BA09D28A821EE81C243E3DDD6F4C1F41D6ADEAC74D42B221645ADCC69E2F22ECDCAA010F63CCD02EAF0CE20F98439DAC7C31E528A7574656191150C1CC6CCD9FBEFCBFC9B34029FAB8F62DBC1C1618628FF0529B4E66B8AB857A79CC2FD0F14299A3505D22F964322755E6190EDD5BD42066D88154F950585236B6A2951D28BDA474E3FB17638DAA2F6304EAEA3AB9513DD0604D447000208D55DA4FDF544BEE00B5744170C1FC1E6DC6AADA07BEF6EB1FA46C14B99C3371491816A5C2CF7E03EDF6D58142767F7550DFFFE634FA56532605768FFEC1B20BEC32177816DDAB804149E9A301E495F11568F58896E90B1AC5776C2F12CE578955292F640A1E81213AAAA7856CD622FC241C65AC08215B94F933FD47050E0CFB2BFA85D7570A9D401B2366001AA377C50825B6D3893BDEC46D87F9121EC39DBF948F69399B8E842635556C7BC08E2E0C85CFA3EA2F9E4582ABDB3EB9668C83EDC34A5862F3CBC1A10935A189493D42D5C3FE4AF2BFF29B8464934B221B5A56B407F4E638B6766E6C706996A0252F2DDB30AFC8C1DA65F89987F4A9AA317BB104ED42F749DE3A43C39C515B67B3EA619D4092843DA551EEFC22CF672F53F753DEB93F1E8487BFE89C0100AFB9799238B24E523B0D6D53F824DEC0F6897F97FA507648D13276841B3B2E98030CBCD8E04F5E2C06C57BCC6F6C346440E620718F8877FFE969',
+                'TestMode' => false,
+            ],
+            $response->getData()
         );
 
-        $response = $this->gateway->completeAuthorize($this->completePurchaseOptions)->send();
+        // Redirect data is just four of the fields in the full data set.
+
+        $this->assertSame(
+            array_intersect_key(
+                $response->getData(),
+                array_flip(['VPSProtocol', 'TxType', 'Vendor', 'Crypt'])
+            ),
+            $response->getRedirectData()
+        );
+
+        // Live (non-test) endpoint.
+        $this->assertSame(
+            'https://live.sagepay.com/gateway/service/vspform-register.vsp',
+            $response->getRedirectUrl()
+        );
+
+        $this->assertSame(
+            'POST',
+            $response->getRedirectMethod()
+        );
+    }
+
+    public function testPurchaseSuccess()
+    {
+        $response = $this->gateway->purchase($this->purchaseOptions)->send();
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertTrue($response->isRedirect());
+
+        $this->assertSame(
+            [
+                'VPSProtocol' => '3.00',
+                'TxType' => 'PAYMENT',
+                'Vendor' => 'example',
+                'Crypt' => '@BE1508740B97BEC235E9E8474168E3D4DEAD71C1395CDAC1A24F4784A71135AE797F5451F48EB2EAF5669EB3F6953F466FC3A03E5815E607C4DD18C03D7BDD61D176DB4DF131DC0F02DFC5145FFBA841651641BDAA405E72F4EF8849C2B2FD1F08763E3E66EAF3C479429A92014C7B8316F3B446BA09D28A821EE81C243E3DDD6F4C1F41D6ADEAC74D42B221645ADCC69E2F22ECDCAA010F63CCD02EAF0CE20F98439DAC7C31E528A7574656191150C1CC6CCD9FBEFCBFC9B34029FAB8F62DBC1C1618628FF0529B4E66B8AB857A79CC2FD0F14299A3505D22F964322755E6190EDD5BD42066D88154F950585236B6A2951D28BDA474E3FB17638DAA2F6304EAEA3AB9513DD0604D447000208D55DA4FDF544BEE00B5744170C1FC1E6DC6AADA07BEF6EB1FA46C14B99C3371491816A5C2CF7E03EDF6D58142767F7550DFFFE634FA56532605768FFEC1B20BEC32177816DDAB804149E9A301E495F11568F58896E90B1AC5776C2F12CE578955292F640A1E81213AAAA7856CD622FC241C65AC08215B94F933FD47050E0CFB2BFA85D7570A9D401B2366001AA377C50825B6D3893BDEC46D87F9121EC39DBF948F69399B8E842635556C7BC08E2E0C85CFA3EA2F9E4582ABDB3EB9668C83EDC34A5862F3CBC1A10935A189493D42D5C3FE4AF2BFF29B8464934B221B5A56B407F4E638B6766E6C706996A0252F2DDB30AFC8C1DA65F89987F4A9AA317BB104ED42F749DE3A43C39C515B67B3EA619D4092843DA551EEFC22CF672F53F753DEB93F1E8487BFE89C0100AFB9799238B24E523B0D6D53F824DEC0F6897F97FA507648D13276841B3B2E98030CBCD8E04F5E2C06C57BCC6F6C346440E620718F8877FFE969',
+                'TestMode' => false,
+            ],
+            $response->getData()
+        );
+    }
+
+    /**
+     * The only real failures are validation exceptions in the data
+     * supplied, which largely amount to missing parameters.
+     *
+     * @dataProvider missingParameterProvider
+     * @expectedException \Omnipay\Common\Exception\InvalidRequestException
+     */
+    public function testAuthorizeFailure($missingParameter)
+    {
+        $parameters = $this->purchaseOptions;
+
+        unset($parameters[$missingParameter]);
+
+        $response = $this->gateway->authorize($parameters)->send();
+    }
+
+    public function missingParameterProvider()
+    {
+        return [
+            ['transactionId'],
+            ['currency'],
+            ['description'],
+            ['encryptionKey'],
+        ];
+    }
+
+    public function testCompleteAuthorizeSuccess()
+    {
+        $crypt = '@5548276239c33e937e4d9d847d0a01f451d692827902c2b0243c371aff9ed7626571de70f86e4d0f11d64b35243794f04405742cc7dc3a559c3b4b94c7b39af3ff0068c41a575d6fe42243e8cf5ba019fdb2f0584c71fb54052c37af483556698e2f96ec4202706f4ccd351c185bfa310970dd6173b726fa01aeafcd2d2df87a656f5f3f28e528e7ab1f64472a978bda1ec7e883e22ce292570ab5599799a823ce45bb3f105330662987da4029a1e24c9f656390a76acf4075a74e4d16b369c663d4baad5a26ecde3c54ab6c90b26a58008b4da1b3665b954e059fb37705834e55f83d6dcf642b13dd6456034d3d78ad307c29eaeb5c1ce8c0f8c5a976d98adcdc763e20c1ea21036b59e7d0cbde381f9a6298e72172677c3b14a4dd1bece0bb575c78dbdb0e0b5d534bf401b6788025a5024f630c1bba0748dacea45a0d22227434ac2bb69b6dd978784ea3835feb2b70e7f9b950186910583aab1444ca4e8eba9ad9769828e0978b5bfa643920175e488b18c9f7ea4d3ff654386bcd8aa19f2873246d5ef445d879c3ed3fa1459d1b';
+
+        // The complete page will receive a sungle "crypt" query parameter.
+
+        $this->getHttpRequest()->query->replace(
+            [
+                'crypt' => $crypt,
+            ]
+        );
+
+        $request = $this->gateway->completeAuthorize($this->completePurchaseOptions);
+
+        $response = $request->send();
 
         $this->assertTrue($response->isSuccessful());
         $this->assertSame(
-            '{"SecurityKey":"JEUPDN1N7E","TxAuthNo":"b","VPSTxId":"{F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2}","VendorTxCode":"123"}',
+            '{"TxAuthNo":"19000362","VPSTxId":"{F5A91F56-F9C7-EFAD-8050-3226BBC6F4A8}","VendorTxCode":"phpne-demo-53922585"}',
             $response->getTransactionReference()
         );
-        $this->assertNull($response->getMessage());
+        $this->assertSame(
+            '0000 : The Authorisation was Successful.',
+            $response->getMessage()
+        );
+
+        $this->assertSame(
+            [
+                'VendorTxCode' => 'phpne-demo-53922585',
+                'VPSTxId' => '{F5A91F56-F9C7-EFAD-8050-3226BBC6F4A8}',
+                'Status' => 'OK',
+                'StatusDetail' => '0000 : The Authorisation was Successful.',
+                'TxAuthNo' => '19000362',
+                'AVSCV2' => 'SECURITY CODE MATCH ONLY',
+                'AddressResult' => 'NOTMATCHED',
+                'PostCodeResult' => 'NOTMATCHED',
+                'CV2Result' => 'MATCHED',
+                'GiftAid' => '0',
+                '3DSecureStatus' => 'NOTCHECKED',
+                'CardType' => 'VISA',
+                'Last4Digits' => '0006',
+                'DeclineCode' => '00',
+                'ExpiryDate' => '1218',
+                'Amount' => '99.99',
+                'BankAuthCode' => '999777',
+            ],
+            $response->getdata()
+        );
     }
-*/
+
     /**
      * @expectedException Omnipay\Common\Exception\InvalidResponseException
      */
@@ -214,134 +260,6 @@ class FormGatewayTest extends GatewayTestCase
 
         $this->assertTrue($response->isSuccessful());
         $this->assertSame('Successful repeat.', $response->getMessage());
-    }
-
-    // Capture
-
-    public function testCaptureSuccess()
-    {
-        $this->setMockHttpResponse('SharedCaptureSuccess.txt');
-
-        $response = $this->gateway->capture($this->captureOptions)->send();
-
-        $this->assertTrue($response->isSuccessful());
-        $this->assertNull($response->getTransactionReference());
-        $this->assertSame('The transaction was RELEASEed successfully.', $response->getMessage());
-    }
-
-    public function testCaptureFailure()
-    {
-        $this->setMockHttpResponse('SharedCaptureFailure.txt');
-
-        $response = $this->gateway->capture($this->captureOptions)->send();
-
-        $this->assertFalse($response->isSuccessful());
-        $this->assertNull($response->getTransactionReference());
-        $this->assertSame('You are trying to RELEASE a transaction that has already been RELEASEd or ABORTed.', $response->getMessage());
-    }
-
-    public function testRepeatAuthorizeFailure()
-    {
-        $this->setMockHttpResponse('SharedRepeatAuthorizeFailure.txt');
-
-        $response = $this->gateway->repeatAuthorize($this->repeatOptions)->send();
-
-        $this->assertFalse($response->isSuccessful());
-        $this->assertSame('Not authorized.', $response->getMessage());
-    }
-
-    // Repeat Purchase
-
-    public function testRepeatPurchaseSuccess()
-    {
-        $this->setMockHttpResponse('SharedRepeatAuthorize.txt');
-
-        $response = $this->gateway->repeatPurchase($this->repeatOptions)->send();
-
-        $this->assertTrue($response->isSuccessful());
-        $this->assertSame('Successful repeat.', $response->getMessage());
-    }
-
-    public function testRepeatPurchaseFailure()
-    {
-        $this->setMockHttpResponse('SharedRepeatAuthorizeFailure.txt');
-
-        $response = $this->gateway->repeatPurchase($this->repeatOptions)->send();
-
-        $this->assertFalse($response->isSuccessful());
-        $this->assertSame('Not authorized.', $response->getMessage());
-    }
-
-    // Void
-
-    public function testVoidSuccess()
-    {
-        $this->setMockHttpResponse('SharedVoidSuccess.txt');
-
-        $response = $this->gateway->void($this->voidOptions)->send();
-
-        $this->assertTrue($response->isSuccessful());
-        $this->assertNull($response->getTransactionReference());
-        $this->assertSame('2005 : The Void was Successful.', $response->getMessage());
-    }
-
-    public function testVoidFailure()
-    {
-        $this->setMockHttpResponse('SharedVoidFailure.txt');
-
-        $response = $this->gateway->void($this->voidOptions)->send();
-
-        $this->assertFalse($response->isSuccessful());
-        $this->assertNull($response->getTransactionReference());
-        $this->assertSame('4041 : The Transaction type does not support the requested operation.', $response->getMessage());
-    }
-
-    // Abort
-
-    public function testAbortSuccess()
-    {
-        $this->setMockHttpResponse('SharedAbortSuccess.txt');
-
-        $response = $this->gateway->abort($this->abortOptions)->send();
-
-        $this->assertTrue($response->isSuccessful());
-        $this->assertNull($response->getTransactionReference());
-        $this->assertSame('2005 : The Abort was Successful.', $response->getMessage());
-    }
-
-    public function testAbortFailure()
-    {
-        $this->setMockHttpResponse('SharedAbortFailure.txt');
-
-        $response = $this->gateway->abort($this->abortOptions)->send();
-
-        $this->assertFalse($response->isSuccessful());
-        $this->assertNull($response->getTransactionReference());
-        $this->assertSame('4041 : The Transaction type does not support the requested operation.', $response->getMessage());
-    }
-
-    // Refund
-
-    public function testRefundSuccess()
-    {
-        $this->setMockHttpResponse('SharedRefundSuccess.txt');
-
-        $response = $this->gateway->refund($this->refundOptions)->send();
-
-        $this->assertTrue($response->isSuccessful());
-        $this->assertSame('{"SecurityKey":"CLSMJYURGO","TxAuthNo":"9962","VPSTxId":"{5A1BC414-5409-48DD-9B8B-DCDF096CE0BE}","VendorTxCode":"123"}', $response->getTransactionReference());
-        $this->assertSame('0000 : The Authorisation was Successful.', $response->getMessage());
-    }
-
-    public function testRefundFailure()
-    {
-        $this->setMockHttpResponse('SharedRefundFailure.txt');
-
-        $response = $this->gateway->refund($this->refundOptions)->send();
-
-        $this->assertFalse($response->isSuccessful());
-        $this->assertSame('{"VPSTxId":"{869BC439-1904-DF8A-DDC6-D13E3599FB98}","VendorTxCode":"123"}', $response->getTransactionReference());
-        $this->assertSame('3013 : The Description is missing.', $response->getMessage());
     }
 */
 }

--- a/tests/FormGatewayTest.php
+++ b/tests/FormGatewayTest.php
@@ -1,0 +1,340 @@
+<?php
+
+namespace Omnipay\SagePay;
+
+use Omnipay\Tests\GatewayTestCase;
+
+class FormGatewayTest extends GatewayTestCase
+{
+    protected $error_3082_text = '3082 : The Description value is too long.';
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->gateway = new ServerGateway($this->getHttpClient(), $this->getHttpRequest());
+        $this->gateway->setVendor('example');
+
+        $this->purchaseOptions = array(
+            'amount' => '10.00',
+            'transactionId' => '123',
+            'card' => $this->getValidCard(),
+            'returnUrl' => 'https://www.example.com/return',
+        );
+
+        $this->captureOptions = array(
+            'amount' => '10.00',
+            'transactionId' => '123',
+            'transactionReference' => '{"SecurityKey":"JEUPDN1N7E","TxAuthNo":"4255","VPSTxId":"{F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2}","VendorTxCode":"438791"}',
+        );
+
+        $this->completePurchaseOptions = array(
+            'amount' => '10.00',
+            'transactionId' => '123',
+            'transactionReference' => '{"SecurityKey":"JEUPDN1N7E","TxAuthNo":"4255","VPSTxId":"{F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2}","VendorTxCode":"438791"}',
+        );
+
+        $this->voidOptions = array(
+            'transactionId' => '123',
+            'transactionReference' => '{"SecurityKey":"JEUPDN1N7E","TxAuthNo":"4255","VPSTxId":"{F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2}","VendorTxCode":"438791"}',
+        );
+
+        $this->abortOptions = array(
+            'transactionId' => '123',
+            'transactionReference' => '{"SecurityKey":"JEUPDN1N7E","TxAuthNo":"4255","VPSTxId":"{F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2}","VendorTxCode":"438791"}',
+        );
+
+        $this->refundOptions = array(
+            'amount' => '10.00',
+            'currency' => 'GBP',
+            'transactionId' => '123',
+            'transactionReference' => '{"SecurityKey":"JEUPDN1N7E","TxAuthNo":"4255","VPSTxId":"{F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2}","VendorTxCode":"438791"}',
+            'description' => 'Some kind of refund',
+        );
+
+        $this->repeatOptions = array(
+            'amount' => '10.00',
+            'currency' => 'GBP',
+            'transactionId' => '123',
+            'transactionReference' => '{"SecurityKey":"JEUPDN1N7E","TxAuthNo":"4255","VPSTxId":"{F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2}","VendorTxCode":"438791"}',
+            'description' => 'Some kind of repeat payment',
+        );
+    }
+
+    public function testInheritsDirectGateway()
+    {
+        $this->assertInstanceOf('Omnipay\SagePay\DirectGateway', $this->gateway);
+    }
+
+    public function testAuthorizeSuccess()
+    {
+        $this->setMockHttpResponse('ServerPurchaseSuccess.txt');
+
+        $response = $this->gateway->authorize($this->purchaseOptions)->send();
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertTrue($response->isRedirect());
+        $this->assertSame('{"SecurityKey":"IK776BWNHN","VPSTxId":"{1E7D9C70-DBE2-4726-88EA-D369810D801D}","VendorTxCode":"123"}', $response->getTransactionReference());
+        $this->assertSame('Server transaction registered successfully.', $response->getMessage());
+        $this->assertSame('https://test.sagepay.com/Simulator/VSPServerPaymentPage.asp?TransactionID={1E7D9C70-DBE2-4726-88EA-D369810D801D}', $response->getRedirectUrl());
+    }
+
+    public function testAuthorizeFailure()
+    {
+        $this->setMockHttpResponse('ServerPurchaseFailure.txt');
+
+        $response = $this->gateway->authorize($this->purchaseOptions)->send();
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertSame($this->error_3082_text, $response->getMessage());
+    }
+
+    public function testCompleteAuthorizeSuccess()
+    {
+        $this->getHttpRequest()->request->replace(
+            array(
+                'Status' => 'OK',
+                'TxAuthNo' => 'b',
+                'AVSCV2' => 'c',
+                'AddressResult' => 'd',
+                'PostCodeResult' => 'e',
+                'CV2Result' => 'f',
+                'GiftAid' => 'g',
+                '3DSecureStatus' => 'h',
+                'CAVV' => 'i',
+                'AddressStatus' => 'j',
+                'PayerStatus' => 'k',
+                'CardType' => 'l',
+                'Last4Digits' => 'm',
+                // New fields for protocol v3.00
+                'DeclineCode' => '00',
+                'ExpiryDate' => '0722',
+                'BankAuthCode' => '999777',
+                'VPSSignature' => md5(
+                    '{F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2}'
+                    . '438791' . 'OK' . 'bexamplecJEUPDN1N7Edefghijklm' . '00' . '0722' . '999777'
+                ),
+            )
+        );
+
+        $response = $this->gateway->completeAuthorize($this->completePurchaseOptions)->send();
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertSame(
+            '{"SecurityKey":"JEUPDN1N7E","TxAuthNo":"b","VPSTxId":"{F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2}","VendorTxCode":"123"}',
+            $response->getTransactionReference()
+        );
+        $this->assertNull($response->getMessage());
+    }
+
+    /**
+     * @expectedException Omnipay\Common\Exception\InvalidResponseException
+     */
+    public function testCompleteAuthorizeInvalid()
+    {
+        $response = $this->gateway->completeAuthorize($this->completePurchaseOptions)->send();
+    }
+
+    public function testPurchaseSuccess()
+    {
+        $this->setMockHttpResponse('ServerPurchaseSuccess.txt');
+
+        $response = $this->gateway->purchase($this->purchaseOptions)->send();
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertTrue($response->isRedirect());
+        $this->assertSame('{"SecurityKey":"IK776BWNHN","VPSTxId":"{1E7D9C70-DBE2-4726-88EA-D369810D801D}","VendorTxCode":"123"}', $response->getTransactionReference());
+        $this->assertSame('Server transaction registered successfully.', $response->getMessage());
+        $this->assertSame('https://test.sagepay.com/Simulator/VSPServerPaymentPage.asp?TransactionID={1E7D9C70-DBE2-4726-88EA-D369810D801D}', $response->getRedirectUrl());
+    }
+
+    public function testPurchaseFailure()
+    {
+        $this->setMockHttpResponse('ServerPurchaseFailure.txt');
+
+        $response = $this->gateway->purchase($this->purchaseOptions)->send();
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertSame($this->error_3082_text, $response->getMessage());
+    }
+
+    public function testCompletePurchaseSuccess()
+    {
+        $this->getHttpRequest()->request->replace(
+            array(
+                'Status' => 'OK',
+                'TxAuthNo' => 'b',
+                'AVSCV2' => 'c',
+                'AddressResult' => 'd',
+                'PostCodeResult' => 'e',
+                'CV2Result' => 'f',
+                'GiftAid' => 'g',
+                '3DSecureStatus' => 'h',
+                'CAVV' => 'i',
+                'AddressStatus' => 'j',
+                'PayerStatus' => 'k',
+                'CardType' => 'l',
+                'Last4Digits' => 'm',
+                'VPSSignature' => md5('{F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2}438791OKbexamplecJEUPDN1N7Edefghijklm'),
+            )
+        );
+
+        $response = $this->gateway->completePurchase($this->completePurchaseOptions)->send();
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertSame('{"SecurityKey":"JEUPDN1N7E","TxAuthNo":"b","VPSTxId":"{F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2}","VendorTxCode":"123"}', $response->getTransactionReference());
+        $this->assertNull($response->getMessage());
+    }
+
+    /**
+     * @expectedException Omnipay\Common\Exception\InvalidResponseException
+     */
+    public function testCompletePurchaseInvalid()
+    {
+        $response = $this->gateway->completePurchase($this->completePurchaseOptions)->send();
+    }
+
+    // Repeat Authorize
+
+    public function testRepeatAuthorizeSuccess()
+    {
+        $this->setMockHttpResponse('SharedRepeatAuthorize.txt');
+
+        $response = $this->gateway->repeatAuthorize($this->repeatOptions)->send();
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertSame('Successful repeat.', $response->getMessage());
+    }
+
+    // Capture
+
+    public function testCaptureSuccess()
+    {
+        $this->setMockHttpResponse('SharedCaptureSuccess.txt');
+
+        $response = $this->gateway->capture($this->captureOptions)->send();
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertSame('The transaction was RELEASEed successfully.', $response->getMessage());
+    }
+
+    public function testCaptureFailure()
+    {
+        $this->setMockHttpResponse('SharedCaptureFailure.txt');
+
+        $response = $this->gateway->capture($this->captureOptions)->send();
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertSame('You are trying to RELEASE a transaction that has already been RELEASEd or ABORTed.', $response->getMessage());
+    }
+
+    public function testRepeatAuthorizeFailure()
+    {
+        $this->setMockHttpResponse('SharedRepeatAuthorizeFailure.txt');
+
+        $response = $this->gateway->repeatAuthorize($this->repeatOptions)->send();
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertSame('Not authorized.', $response->getMessage());
+    }
+
+    // Repeat Purchase
+
+    public function testRepeatPurchaseSuccess()
+    {
+        $this->setMockHttpResponse('SharedRepeatAuthorize.txt');
+
+        $response = $this->gateway->repeatPurchase($this->repeatOptions)->send();
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertSame('Successful repeat.', $response->getMessage());
+    }
+
+    public function testRepeatPurchaseFailure()
+    {
+        $this->setMockHttpResponse('SharedRepeatAuthorizeFailure.txt');
+
+        $response = $this->gateway->repeatPurchase($this->repeatOptions)->send();
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertSame('Not authorized.', $response->getMessage());
+    }
+
+    // Void
+
+    public function testVoidSuccess()
+    {
+        $this->setMockHttpResponse('SharedVoidSuccess.txt');
+
+        $response = $this->gateway->void($this->voidOptions)->send();
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertSame('2005 : The Void was Successful.', $response->getMessage());
+    }
+
+    public function testVoidFailure()
+    {
+        $this->setMockHttpResponse('SharedVoidFailure.txt');
+
+        $response = $this->gateway->void($this->voidOptions)->send();
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertSame('4041 : The Transaction type does not support the requested operation.', $response->getMessage());
+    }
+
+    // Abort
+
+    public function testAbortSuccess()
+    {
+        $this->setMockHttpResponse('SharedAbortSuccess.txt');
+
+        $response = $this->gateway->abort($this->abortOptions)->send();
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertSame('2005 : The Abort was Successful.', $response->getMessage());
+    }
+
+    public function testAbortFailure()
+    {
+        $this->setMockHttpResponse('SharedAbortFailure.txt');
+
+        $response = $this->gateway->abort($this->abortOptions)->send();
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertSame('4041 : The Transaction type does not support the requested operation.', $response->getMessage());
+    }
+
+    // Refund
+
+    public function testRefundSuccess()
+    {
+        $this->setMockHttpResponse('SharedRefundSuccess.txt');
+
+        $response = $this->gateway->refund($this->refundOptions)->send();
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertSame('{"SecurityKey":"CLSMJYURGO","TxAuthNo":"9962","VPSTxId":"{5A1BC414-5409-48DD-9B8B-DCDF096CE0BE}","VendorTxCode":"123"}', $response->getTransactionReference());
+        $this->assertSame('0000 : The Authorisation was Successful.', $response->getMessage());
+    }
+
+    public function testRefundFailure()
+    {
+        $this->setMockHttpResponse('SharedRefundFailure.txt');
+
+        $response = $this->gateway->refund($this->refundOptions)->send();
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertSame('{"VPSTxId":"{869BC439-1904-DF8A-DDC6-D13E3599FB98}","VendorTxCode":"123"}', $response->getTransactionReference());
+        $this->assertSame('3013 : The Description is missing.', $response->getMessage());
+    }
+}

--- a/tests/FormGatewayTest.php
+++ b/tests/FormGatewayTest.php
@@ -12,7 +12,10 @@ class FormGatewayTest extends GatewayTestCase
     {
         parent::setUp();
 
-        $this->gateway = new ServerGateway($this->getHttpClient(), $this->getHttpRequest());
+        $this->gateway = new FormGateway(
+            $this->getHttpClient(),
+            $this->getHttpRequest()
+        );
         $this->gateway->setVendor('example');
 
         $this->purchaseOptions = array(
@@ -20,6 +23,7 @@ class FormGatewayTest extends GatewayTestCase
             'transactionId' => '123',
             'card' => $this->getValidCard(),
             'returnUrl' => 'https://www.example.com/return',
+            'encryptionKey' => '12345678abcdeabc',
         );
 
         $this->captureOptions = array(
@@ -32,6 +36,7 @@ class FormGatewayTest extends GatewayTestCase
             'amount' => '10.00',
             'transactionId' => '123',
             'transactionReference' => '{"SecurityKey":"JEUPDN1N7E","TxAuthNo":"4255","VPSTxId":"{F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2}","VendorTxCode":"438791"}',
+            'encryptionKey' => '12345678abcdeabc',
         );
 
         $this->voidOptions = array(
@@ -63,7 +68,7 @@ class FormGatewayTest extends GatewayTestCase
 
     public function testInheritsDirectGateway()
     {
-        $this->assertInstanceOf('Omnipay\SagePay\DirectGateway', $this->gateway);
+        $this->assertInstanceOf(\Omnipay\SagePay\FormGateway::class, $this->gateway);
     }
 
     public function testAuthorizeSuccess()
@@ -74,9 +79,8 @@ class FormGatewayTest extends GatewayTestCase
 
         $this->assertFalse($response->isSuccessful());
         $this->assertTrue($response->isRedirect());
-        $this->assertSame('{"SecurityKey":"IK776BWNHN","VPSTxId":"{1E7D9C70-DBE2-4726-88EA-D369810D801D}","VendorTxCode":"123"}', $response->getTransactionReference());
-        $this->assertSame('Server transaction registered successfully.', $response->getMessage());
-        $this->assertSame('https://test.sagepay.com/Simulator/VSPServerPaymentPage.asp?TransactionID={1E7D9C70-DBE2-4726-88EA-D369810D801D}', $response->getRedirectUrl());
+
+        // TODO: look at the redirect data.
     }
 
     public function testAuthorizeFailure()
@@ -86,11 +90,9 @@ class FormGatewayTest extends GatewayTestCase
         $response = $this->gateway->authorize($this->purchaseOptions)->send();
 
         $this->assertFalse($response->isSuccessful());
-        $this->assertFalse($response->isRedirect());
-        $this->assertNull($response->getTransactionReference());
-        $this->assertSame($this->error_3082_text, $response->getMessage());
+        $this->assertTrue($response->isRedirect());
     }
-
+/*
     public function testCompleteAuthorizeSuccess()
     {
         $this->getHttpRequest()->request->replace(
@@ -128,10 +130,11 @@ class FormGatewayTest extends GatewayTestCase
         );
         $this->assertNull($response->getMessage());
     }
-
+*/
     /**
      * @expectedException Omnipay\Common\Exception\InvalidResponseException
      */
+/*
     public function testCompleteAuthorizeInvalid()
     {
         $response = $this->gateway->completeAuthorize($this->completePurchaseOptions)->send();
@@ -189,10 +192,11 @@ class FormGatewayTest extends GatewayTestCase
         $this->assertSame('{"SecurityKey":"JEUPDN1N7E","TxAuthNo":"b","VPSTxId":"{F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2}","VendorTxCode":"123"}', $response->getTransactionReference());
         $this->assertNull($response->getMessage());
     }
-
+*/
     /**
      * @expectedException Omnipay\Common\Exception\InvalidResponseException
      */
+/*
     public function testCompletePurchaseInvalid()
     {
         $response = $this->gateway->completePurchase($this->completePurchaseOptions)->send();
@@ -337,4 +341,5 @@ class FormGatewayTest extends GatewayTestCase
         $this->assertSame('{"VPSTxId":"{869BC439-1904-DF8A-DDC6-D13E3599FB98}","VendorTxCode":"123"}', $response->getTransactionReference());
         $this->assertSame('3013 : The Description is missing.', $response->getMessage());
     }
+*/
 }


### PR DESCRIPTION
Support Sage Pay Form

A little refactoring included to help support this payment method with a little less code duplication.

Also includes issue #114 so that the [mandatory] delivery address can be set to copy the billing address automatically.

TOO: More parameters to be supported, along with tests, so this PR is mot final yet, but it will remain stable, so is here for visibility if you would like to give it a go.