### PR TITLE
Require correct PHP version on composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [Omnipay](https://github.com/thephpleague/omnipay) is a framework agnostic,
 multi-gateway payment processing library for PHP.
 This package implements Sage Pay support for Omnipay.
-This version only supports PHP 7.1+.
+This version supports PHP ^5.6 and PHP ^7.
 
 This is the `master` branch of Omnipay, handling Omnipay version `3.x`.
 For the `2.x` branch, please visit https://github.com/thephpleague/omnipay-sagepay/tree/2.x

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         }
     },
     "require": {
-        "php": "^7.1",
+        "php": "^5.6|^7",
         "omnipay/common": "~3.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         }
     },
     "require": {
+        "php": "^7.1",
         "omnipay/common": "~3.0"
     },
     "require-dev": {


### PR DESCRIPTION
Since `omnipay/common` requires PHP 5 and this package doesn't require any PHP version BUT works only with PHP 7.1+, then it should have the right PHP version to be required in order to avoid this package being required in the wrong php environment.