### PR TITLE
Support isSuccessful() in acceptNotification

### DIFF
--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -16,17 +16,6 @@ class Response extends AbstractResponse implements RedirectResponseInterface, Co
     use ResponseFieldsTrait;
 
     /**
-     * @return bool True if the transaction is successful and complete.
-     */
-    public function isSuccessful()
-    {
-        return $this->getStatus() === static::SAGEPAY_STATUS_OK
-            || $this->getStatus() === static::SAGEPAY_STATUS_OK_REPEATED
-            || $this->getStatus() === static::SAGEPAY_STATUS_REGISTERED
-            || $this->getStatus() === static::SAGEPAY_STATUS_AUTHENTICATED;
-    }
-
-    /**
      * Gateway Reference
      *
      * Sage Pay requires the original VendorTxCode as well as 3 separate

--- a/src/Traits/ResponseFieldsTrait.php
+++ b/src/Traits/ResponseFieldsTrait.php
@@ -24,6 +24,17 @@ trait ResponseFieldsTrait
     }
 
     /**
+     * @return bool True if the transaction is successful and complete.
+     */
+    public function isSuccessful()
+    {
+        return $this->getStatus() === static::SAGEPAY_STATUS_OK
+            || $this->getStatus() === static::SAGEPAY_STATUS_OK_REPEATED
+            || $this->getStatus() === static::SAGEPAY_STATUS_REGISTERED
+            || $this->getStatus() === static::SAGEPAY_STATUS_AUTHENTICATED;
+    }
+
+    /**
      * Get the cardReference generated when creating a card reference
      * during an authorisation or payment, or as an explicit request.
      *

--- a/tests/Message/ServerNotifyRequestTest.php
+++ b/tests/Message/ServerNotifyRequestTest.php
@@ -100,6 +100,12 @@ class ServerNotifyRequestTest extends TestCase
             "Status=OK\r\nRedirectUrl=https://www.example.com/\r\nStatusDetail=detail"
         );
         $this->request->confirm('https://www.example.com/', 'detail');
+
+        // Issue https://github.com/thephpleague/omnipay-sagepay/issues/124
+        // The isSuccessful() method is moved to the trait that shares many
+        // common response fields with the notification server request.
+
+        $this->assertTrue($this->request->isSuccessful());
     }
 
     public function testServerNotifyRequestFailure()


### PR DESCRIPTION
Allows the notification handler to check if he transaction was successful for use in its business decisions.