### PR TITLE
Update AuthorizeRequest.php

### DIFF
--- a/src/Message/Form/AuthorizeRequest.php
+++ b/src/Message/Form/AuthorizeRequest.php
@@ -26,7 +26,7 @@ class AuthorizeRequest extends DirectAuthorizeRequest
         'CustomerName' => false,
         'CustomerEMail' => false,
         'VendorEMail' => false,
-        'SendEMail' => false,
+        'SendEmail' => false,
         'EmailMessage' => false,
         'BillingSurname' => true,
         'BillingFirstnames' => true,

--- a/src/Message/Form/AuthorizeRequest.php
+++ b/src/Message/Form/AuthorizeRequest.php
@@ -26,7 +26,7 @@ class AuthorizeRequest extends DirectAuthorizeRequest
         'CustomerName' => false,
         'CustomerEMail' => false,
         'VendorEMail' => false,
-        'SendEmail' => false,
+        'SendEMail' => false,
         'EmailMessage' => false,
         'BillingSurname' => true,
         'BillingFirstnames' => true,
@@ -100,7 +100,7 @@ class AuthorizeRequest extends DirectAuthorizeRequest
         }
 
         if ($this->getVendorEmail() !== null) {
-            $data['VendorEmail'] = $this->getVendorEmail();
+            $data['VendorEMail'] = $this->getVendorEmail();
         }
 
         if ($this->getEmailMessage() !== null) {
@@ -124,7 +124,7 @@ class AuthorizeRequest extends DirectAuthorizeRequest
                 $sendEmail = static::SEND_EMAIL_BOTH;
             }
 
-            $data['SendEmail'] = $this->getSendEmail();
+            $data['SendEMail'] = $this->getSendEmail();
         }
 
         $data['SuccessURL'] = $this->getReturnUrl();


### PR DESCRIPTION
I've come across an issue with the SendEmail option in 
Omnipay\SagePay\Message\Form\AuthorizeRequest

At https://github.com/thephpleague/omnipay-sagepay/blob/master/src/Message/Form/AuthorizeRequest.php#L127
$data['SendEmail'] is set up, but this is filtered out by a mismatch in case sensitivity
at https://github.com/thephpleague/omnipay-sagepay/blob/master/src/Message/Form/AuthorizeRequest.php#L29

The same appears to be true for $data['VendorEmail'], which is set up at https://github.com/thephpleague/omnipay-sagepay/blob/master/src/Message/Form/AuthorizeRequest.php#L103 but then filtered out by the mismatch in case sensitivity at https://github.com/thephpleague/omnipay-sagepay/blob/master/src/Message/Form/AuthorizeRequest.php#L28

It seems like the correct data should be SendEMail and VendorEMail, so I'm proposing a change in the lines that set up the $data array.