### PR TITLE
Add SagePay Direct PayPal integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,8 @@
     },
     "require": {
         "php": "^5.6|^7",
+        "ext-json": "*",
+        "ext-simplexml": "*",
         "omnipay/common": "~3.0"
     },
     "require-dev": {

--- a/src/ConstantsInterface.php
+++ b/src/ConstantsInterface.php
@@ -106,6 +106,7 @@ interface ConstantsInterface
     const TXTYPE_REFUND         = 'REFUND';
     const TXTYPE_REPEAT         = 'REPEAT';
     const TXTYPE_REPEATDEFERRED = 'REPEATDEFERRED';
+    const TXTYPE_COMPLETE       = 'COMPLETE';
 
     /**
      *
@@ -115,6 +116,7 @@ interface ConstantsInterface
     const SERVICE_REPEAT            = 'repeat';
     const SERVICE_TOKEN             = 'directtoken';
     const SERVICE_DIRECT3D          = 'direct3dcallback';
+    const SERVICE_PAYPAL            = 'complete';
 
     /**
      * 0 = Do not send either customer or vendor emails
@@ -149,6 +151,7 @@ interface ConstantsInterface
     const SAGEPAY_STATUS_MALFORMED      = 'MALFORMED';
     const SAGEPAY_STATUS_INVALID        = 'INVALID';
     const SAGEPAY_STATUS_ERROR          = 'ERROR';
+    const SAGEPAY_STATUS_PAYPALOK       = 'PAYPALOK';
 
     /**
      * Raw values for AddressResult

--- a/src/DirectGateway.php
+++ b/src/DirectGateway.php
@@ -86,7 +86,7 @@ class DirectGateway extends AbstractGateway
     }
 
     /**
-     * Void a completed (captured) transation.
+     * Void a completed (captured) transaction.
      */
     public function refund(array $parameters = [])
     {

--- a/src/DirectGateway.php
+++ b/src/DirectGateway.php
@@ -4,6 +4,7 @@ namespace Omnipay\SagePay;
 
 use Omnipay\SagePay\Message\DirectAuthorizeRequest;
 use Omnipay\SagePay\Message\DirectCompleteAuthorizeRequest;
+use Omnipay\SagePay\Message\DirectCompletePayPalRequest;
 use Omnipay\SagePay\Message\DirectPurchaseRequest;
 use Omnipay\SagePay\Message\SharedCaptureRequest;
 use Omnipay\SagePay\Message\SharedVoidRequest;
@@ -42,6 +43,11 @@ class DirectGateway extends AbstractGateway
     public function completeAuthorize(array $parameters = [])
     {
         return $this->createRequest(DirectCompleteAuthorizeRequest::class, $parameters);
+    }
+
+    public function completePayPal(array $parameters = [])
+    {
+        return $this->createRequest(DirectCompletePayPalRequest::class, $parameters);
     }
 
     /**

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -437,11 +437,10 @@ abstract class AbstractRequest extends OmnipayAbstractRequest implements Constan
      * Values defined in static::ALLOW_GIFT_AID_* constant.
      *
      * @param bool|int $allowGiftAid value that casts to boolean
-     * @return $this
      */
-    public function setAllowGiftAid($value)
+    public function setAllowGiftAid($allowGiftAid)
     {
-        $this->setParameter('allowGiftAid', $value);
+        $this->setParameter('allowGiftAid', $allowGiftAid);
     }
 
     /**

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -60,7 +60,7 @@ abstract class AbstractRequest extends OmnipayAbstractRequest implements Constan
     }
 
     /**
-     * If it is used, i.e. needed for an enpoint, then it must be defined.
+     * If it is used, i.e. needed for an endpoint, then it must be defined.
      *
      * @return string the transaction type.
      * @throws InvalidRequestException
@@ -185,7 +185,7 @@ abstract class AbstractRequest extends OmnipayAbstractRequest implements Constan
      * then use that to instantiate the response object.
      *
      * @param  array
-     * @return Response The reponse object initialised with the data returned from the gateway.
+     * @return Response The response object initialised with the data returned from the gateway.
      */
     public function sendData($data)
     {
@@ -332,7 +332,7 @@ abstract class AbstractRequest extends OmnipayAbstractRequest implements Constan
     /**
      * An optional flag to indicate if you wish to continue to store the
      * Token in the SagePay token database for future use.
-     * Values set in contants SET_TOKEN_*
+     * Values set in constants SET_TOKEN_*
      *
      * Note: this is just an override method. It is best to leave this unset,
      * and use either setToken or setCardReference. This flag will then be

--- a/src/Message/DirectAuthorizeRequest.php
+++ b/src/Message/DirectAuthorizeRequest.php
@@ -9,7 +9,7 @@ namespace Omnipay\SagePay\Message;
 class DirectAuthorizeRequest extends AbstractRequest
 {
     /**
-     * @var array Some mapping from Omnipay card brand codes to Sage Pay card branc codes.
+     * @var array Some mapping from Omnipay card brand codes to Sage Pay card branch codes.
      */
     protected $cardBrandMap = array(
         'mastercard' => 'MC',
@@ -104,7 +104,7 @@ class DirectAuthorizeRequest extends AbstractRequest
      * SagePay throws an error if passed an IPv6 address.
      * Filter out addresses that are not IPv4 format.
      *
-     * @return string|null The IPv4 IP addess string or null if not available in this format.
+     * @return string|null The IPv4 IP address string or null if not available in this format.
      */
     public function getClientIp()
     {
@@ -247,7 +247,7 @@ class DirectAuthorizeRequest extends AbstractRequest
         // A CVV may be supplied whether using a token or credit card details.
         // On *first* use of a token for which a CVV was provided, that CVV will
         // be used when making a transaction. The CVV will then be deleted by the
-        // gateway. For each *resuse* of a cardReference, a new CVV must be provided,
+        // gateway. For each *reuse* of a cardReference, a new CVV must be provided,
         // if the security rules require it.
 
         if ($this->getCard()->getCvv() !== null) {
@@ -285,7 +285,7 @@ class DirectAuthorizeRequest extends AbstractRequest
     }
 
     /**
-     * @return string The XML surchange data as set.
+     * @return string The XML surcharge data as set.
      */
     public function getSurchargeXml()
     {

--- a/src/Message/DirectAuthorizeRequest.php
+++ b/src/Message/DirectAuthorizeRequest.php
@@ -2,6 +2,8 @@
 
 namespace Omnipay\SagePay\Message;
 
+use Omnipay\SagePay\PayPal;
+
 /**
  * Sage Pay Direct Authorize Request
  */
@@ -9,7 +11,7 @@ namespace Omnipay\SagePay\Message;
 class DirectAuthorizeRequest extends AbstractRequest
 {
     /**
-     * @var array Some mapping from Omnipay card brand codes to Sage Pay card branch codes.
+     * @var array Some mapping from Omnipay card brand codes to Sage Pay card brand codes.
      */
     protected $cardBrandMap = array(
         'mastercard' => 'MC',
@@ -191,6 +193,14 @@ class DirectAuthorizeRequest extends AbstractRequest
         // Validate the card details (number, date, cardholder name).
         $this->getCard()->validate();
 
+        $data['CardType'] = $this->getCardBrand();
+
+        if ($this->isPayPalPayment()) {
+            $data['PayPalCallbackURL'] = $this->getCard()->getCallbackUrl();
+
+            return $data;
+        }
+
         if ($this->getCardholderName()) {
             $data['CardHolder'] = $this->getCardholderName();
         } else {
@@ -203,7 +213,6 @@ class DirectAuthorizeRequest extends AbstractRequest
         }
 
         $data['ExpiryDate'] = $this->getCard()->getExpiryDate('my');
-        $data['CardType'] = $this->getCardBrand();
 
         if ($this->getCard()->getStartMonth() and $this->getCard()->getStartYear()) {
             $data['StartDate'] = $this->getCard()->getStartDate('my');
@@ -290,5 +299,13 @@ class DirectAuthorizeRequest extends AbstractRequest
     public function getSurchargeXml()
     {
         return $this->getParameter('surchargeXml');
+    }
+
+    /**
+     * @return bool
+     */
+    protected function isPayPalPayment()
+    {
+        return $this->getCardBrand() === 'PAYPAL' && $this->getCard() instanceof PayPal;
     }
 }

--- a/src/Message/DirectCompletePayPalRequest.php
+++ b/src/Message/DirectCompletePayPalRequest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Omnipay\SagePay\Message;
+
+use Omnipay\Common\Exception\InvalidRequestException;
+
+/**
+ * Sage Pay Direct Complete PayPal Request.
+ */
+class DirectCompletePayPalRequest extends AbstractRequest
+{
+    /**
+     * @return string
+     */
+    public function getService()
+    {
+        return static::SERVICE_PAYPAL;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTxType()
+    {
+        return static::TXTYPE_COMPLETE;
+    }
+
+    /**
+     * @return array|mixed
+     * @throws InvalidRequestException
+     */
+    public function getData()
+    {
+        return $this->getBaseAuthorizeData();
+    }
+
+    /**
+     * The required fields concerning what is being authorised and who
+     * it is being authorised for.
+     *
+     * @return array
+     * @throws InvalidRequestException
+     */
+    protected function getBaseAuthorizeData()
+    {
+        $this->validate('transactionId', 'amount', 'accept');
+
+        // Start with the authorisation and API version details.
+        $data = $this->getBaseData();
+
+        // Money formatted as major unit decimal.
+        $data['VPSTxId'] = $this->getTransactionId();
+        $data['Amount'] = $this->getAmount();
+        $data['Accept'] = !$this->getAccept() || strtoupper($this->getAccept()) === 'NO' ? 'NO' : 'YES';
+
+        return $data;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAccept()
+    {
+        return $this->getParameter('accept');
+    }
+
+    /**
+     * Override the MD passed into the current request.
+     *
+     * @param string $value
+     * @return $this
+     */
+    public function setAccept($value)
+    {
+        return $this->setParameter('accept', $value);
+    }
+}

--- a/src/Message/DirectTokenRegistrationRequest.php
+++ b/src/Message/DirectTokenRegistrationRequest.php
@@ -37,7 +37,7 @@ class DirectTokenRegistrationRequest extends AbstractRequest
         $data['CV2'] = $this->getCard()->getCvv();
         $data['CardType'] = $this->getCardBrand();
 
-        // The account type only comes into play when a transation is requested.
+        // The account type only comes into play when a transaction is requested.
         unset($data['AccountType']);
 
         return $data;

--- a/src/Message/Form/AuthorizeRequest.php
+++ b/src/Message/Form/AuthorizeRequest.php
@@ -186,7 +186,7 @@ class AuthorizeRequest extends DirectAuthorizeRequest
         // is used to submit the form, because that is how the gateway treats
         // the data internally.
         // This package assumes input data will be UTF-8 by default, and will
-        // comvert it accordingly. This can be disabled if the data is already
+        // convert it accordingly. This can be disabled if the data is already
         // ISO8859-1.
         // For the Server and Direct gateway methods, the POST encoding type
         // will tell the gateway how to interpret the character encoding, and
@@ -211,7 +211,7 @@ class AuthorizeRequest extends DirectAuthorizeRequest
 
         $key = $this->getEncryptionKey();
 
-        // Normally IV (paramert 5, initialization vector) would be a kind of salt.
+        // Normally IV (parameter 5, initialization vector) would be a kind of salt.
         // That is more relevant when encrypting user details where multiple users
         // could have identical passwords. But this is a one-off transport of a message
         // that will always be unique, so no variable IV is needed.

--- a/src/Message/ServerAuthorizeResponse.php
+++ b/src/Message/ServerAuthorizeResponse.php
@@ -48,7 +48,7 @@ class ServerAuthorizeResponse extends Response
     }
 
     /**
-     * @return array empy array; all the data is in the GET URL
+     * @return array empty array; all the data is in the GET URL
      */
     public function getRedirectData()
     {

--- a/src/Message/ServerCompleteAuthorizeResponse.php
+++ b/src/Message/ServerCompleteAuthorizeResponse.php
@@ -46,10 +46,10 @@ class ServerCompleteAuthorizeResponse extends Response
      * Error (Sage Pay Server only)
      *
      * Notify Sage Pay you received the payment details but there was an error and the payment
-     * cannot be completed. Error should be called rarely, and only when something unforseen
+     * cannot be completed. Error should be called rarely, and only when something unforeseen
      * has happened on your server or database.
      *
-     * @param string URL to foward the customer to. Note this is different to your standard
+     * @param string URL to forward the customer to. Note this is different to your standard
      *               return controller action URL.
      * @param string Optional human readable reasons for not accepting the transaction.
      */
@@ -66,7 +66,7 @@ class ServerCompleteAuthorizeResponse extends Response
      * of the POST, such as the MD5 hash signatures did not match or you do not wish to proceed
      * with the order.
      *
-     * @param string URL to foward the customer to. Note this is different to your standard
+     * @param string URL to forward the customer to. Note this is different to your standard
      *               return controller action URL.
      * @param string Optional human readable reasons for not accepting the transaction.
      */

--- a/src/Message/ServerNotifyRequest.php
+++ b/src/Message/ServerNotifyRequest.php
@@ -65,7 +65,7 @@ class ServerNotifyRequest extends AbstractRequest implements NotificationInterfa
     {
         if (strpos($reference, 'SecurityKey') !== false) {
             // A JSON string provided - the legacy transactionReference format.
-            // Decode it then extact the securityKey.
+            // Decode it then extract the securityKey.
             // We only need the security key here for the signature; all other
             // items from the reference will be in the server request.
 
@@ -138,7 +138,7 @@ class ServerNotifyRequest extends AbstractRequest implements NotificationInterfa
      * Notify Sage Pay you received the payment details but there was an error and the payment
      * cannot be completed.
      *
-     * @param string URL to foward the customer to.
+     * @param string URL to forward the customer to.
      * @param string Optional human readable reasons for not accepting the transaction.
      */
     public function error($nextUrl, $detail = null)
@@ -168,7 +168,7 @@ class ServerNotifyRequest extends AbstractRequest implements NotificationInterfa
      * of the POST, such as the MD5 hash signatures did not match or you do not wish to proceed
      * with the order.
      *
-     * @param string URL to foward the customer to.
+     * @param string URL to forward the customer to.
      * @param string Optional human readable reasons for not accepting the transaction.
      */
     public function invalid($nextUrl, $detail = null)

--- a/src/PayPal.php
+++ b/src/PayPal.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Omnipay\SagePay;
+
+use Omnipay\Common\CreditCard;
+use Omnipay\Common\Exception\InvalidCreditCardException;
+
+/**
+ * Class PayPal
+ * @package Omnipay\Common
+ */
+class PayPal extends CreditCard
+{
+    /**
+     * PayPal Brand
+     *
+     * Returns a card type of PayPal
+     *
+     * @return string
+     */
+    public function getBrand()
+    {
+        return 'paypal';
+    }
+
+    /**
+     * PayPal payment does not require card detail validation
+     *
+     * @return void
+     * @throws InvalidCreditCardException
+     */
+    public function validate()
+    {
+        $requiredParameters = array(
+            'callbackUrl' => 'PayPal callback URL',
+        );
+
+        foreach ($requiredParameters as $key => $val) {
+            if (!$this->getParameter($key)) {
+                throw new InvalidCreditCardException("The $val is required");
+            }
+        }
+    }
+
+    /**
+     * Get the card CVV.
+     *
+     * @return string
+     */
+    public function getCallbackUrl()
+    {
+        return $this->getParameter('callbackUrl');
+    }
+
+    /**
+     * Sets the card CVV.
+     *
+     * @param string $value
+     * @return $this
+     */
+    public function setCallbackUrl($value)
+    {
+        return $this->setParameter('callbackUrl', $value);
+    }
+}

--- a/src/Traits/GatewayParamsTrait.php
+++ b/src/Traits/GatewayParamsTrait.php
@@ -78,7 +78,7 @@ trait GatewayParamsTrait
      * and this option allows it to be turned back on for legacy
      * merchant sites.
      *
-     * @param mixed true if the notify reponse exits the application.
+     * @param mixed true if the notify response exits the application.
      * @return $this
      */
     public function setExitOnResponse($value)
@@ -87,7 +87,7 @@ trait GatewayParamsTrait
     }
 
     /**
-     * @return mixed true if the notify reponse exits the application.
+     * @return mixed true if the notify response exits the application.
      */
     public function getExitOnResponse()
     {

--- a/src/Traits/ResponseFieldsTrait.php
+++ b/src/Traits/ResponseFieldsTrait.php
@@ -18,8 +18,6 @@ trait ResponseFieldsTrait
      */
     protected function getDataItem($name, $default = null)
     {
-        $data = $this->getData();
-
         return isset($this->data[$name]) ? $this->data[$name] : $default;
     }
 
@@ -31,7 +29,8 @@ trait ResponseFieldsTrait
         return $this->getStatus() === static::SAGEPAY_STATUS_OK
             || $this->getStatus() === static::SAGEPAY_STATUS_OK_REPEATED
             || $this->getStatus() === static::SAGEPAY_STATUS_REGISTERED
-            || $this->getStatus() === static::SAGEPAY_STATUS_AUTHENTICATED;
+            || $this->getStatus() === static::SAGEPAY_STATUS_AUTHENTICATED
+            || $this->getStatus() === static::SAGEPAY_STATUS_PAYPALOK;
     }
 
     /**
@@ -171,7 +170,7 @@ trait ResponseFieldsTrait
     }
 
     /**
-     * The raw frawd response from the gateway.
+     * The raw fraud response from the gateway.
      *
      * @return string One of static::FRAUD_RESPONSE_*
      */
@@ -193,7 +192,7 @@ trait ResponseFieldsTrait
      * The decline code from the bank. These codes are
      * specific to the bank. Please contact them for a description
      * of each code. e.g. 00
-     * @return string Two digit code, specific to the bacnk.
+     * @return string Two digit code, specific to the bank.
      */
     public function getDeclineCode()
     {
@@ -248,6 +247,8 @@ trait ResponseFieldsTrait
         if (! empty($expiryDate)) {
             return (int)substr($expiryDate, 0, 2);
         }
+
+        return null;
     }
 
     /**
@@ -260,10 +261,12 @@ trait ResponseFieldsTrait
         $expiryDate = $this->getDataItem('ExpiryDate');
 
         if (! empty($expiryDate)) {
-            // COnvert 2-digit year to 4-dogot year, in 1970-2069 range.
+            // Convert 2-digit year to 4-digit year, in 1970-2069 range.
             $dateTime = \DateTime::createFromFormat('y', substr($expiryDate, 2, 2));
             return (int)$dateTime->format('Y');
         }
+
+        return null;
     }
 
     /**

--- a/src/Traits/ServerNotifyTrait.php
+++ b/src/Traits/ServerNotifyTrait.php
@@ -47,7 +47,7 @@ trait ServerNotifyTrait
             $VPSTxId = str_replace(['{', '}'], '', $VPSTxId);
         }
 
-        // Transaction types PAYMENT, DEFERRED and AUTHENTICATE (when suppoted)
+        // Transaction types PAYMENT, DEFERRED and AUTHENTICATE (when supported)
         // and non-transaction TOKEN request.
 
         $signatureData = array(

--- a/tests/DirectGatewayTest.php
+++ b/tests/DirectGatewayTest.php
@@ -73,7 +73,7 @@ class DirectGatewayTest extends GatewayTestCase
         $this->assertFalse($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
 
-        // With no suuccess and no redirect, there will be no transaction reference.
+        // With no success and no redirect, there will be no transaction reference.
         //$this->assertSame('{"VendorTxCode":"123"}', $response->getTransactionReference());
         $this->assertNull($response->getTransactionReference());
 

--- a/tests/Message/DirectAuthorizeRequestTest.php
+++ b/tests/Message/DirectAuthorizeRequestTest.php
@@ -6,7 +6,7 @@ use Omnipay\Tests\TestCase;
 
 class DirectAuthorizeRequestTest extends TestCase
 {
-    // VISA incurrs a surcharge of 2.5% when used.
+    // VISA incurs a surcharge of 2.5% when used.
     const SURCHARGE_XML = '<surcharges><surcharge>'
         . '<paymentType>VISA</paymentType><percentage>2.50</percentage>'
         . '</surcharge></surcharges>';
@@ -287,13 +287,13 @@ class DirectAuthorizeRequestTest extends TestCase
     {
         $items = new \Omnipay\Common\ItemBag(array(
             new \Omnipay\Common\Item(array(
-                'name' => "Denisé's Odd & Wierd £name? #12345678901234567890123456789012345678901234567890123456789012345678901234567890",
+                'name' => "Denisé's Odd & Weird £name? #12345678901234567890123456789012345678901234567890123456789012345678901234567890",
                 'description' => 'Description',
                 'quantity' => 2,
                 'price' => 4.23,
             )),
             array(
-                'name' => "Denisé's \"Odd\" & Wierd £discount? #",
+                'name' => "Denisé's \"Odd\" & Weird £discount? #",
                 'description' => 'My Offer',
                 'quantity' => 2,
                 'price' => -0.10,
@@ -309,11 +309,11 @@ class DirectAuthorizeRequestTest extends TestCase
 
         // Names/descriptions should be max 100 characters in length, once invalid characters have been removed.
         $expected = '<basket><item>'
-            . '<description>Denis\'s Odd &amp; Wierd name 123456789012345678901234567890123456789012345678901234567890123456789012345</description><quantity>2</quantity>'
+            . '<description>Denis\'s Odd &amp; Weird name 123456789012345678901234567890123456789012345678901234567890123456789012345</description><quantity>2</quantity>'
             . '<unitNetAmount>4.23</unitNetAmount><unitTaxAmount>0.00</unitTaxAmount>'
             . '<unitGrossAmount>4.23</unitGrossAmount><totalGrossAmount>8.46</totalGrossAmount>'
             . '</item><discounts>'
-            . '<discount><fixed>0.2</fixed><description>Denis\'s "Odd"  Wierd discount? #</description></discount>'
+            . '<discount><fixed>0.2</fixed><description>Denis\'s "Odd"  Weird discount? #</description></discount>'
             . '<discount><fixed>1.6</fixed><description>1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890</description></discount>'
             . '</discounts></basket>';
 

--- a/tests/Message/DirectPurchaseRequestTest.php
+++ b/tests/Message/DirectPurchaseRequestTest.php
@@ -6,7 +6,7 @@ use Omnipay\Tests\TestCase;
 
 class DirectPurchaseRequestTest extends DirectAuthorizeRequestTest
 {
-    // VISA incurrs a surcharge of 2.5% when used.
+    // VISA incurs a surcharge of 2.5% when used.
     const SURCHARGE_XML = '<surcharges><surcharge>'
         . '<paymentType>VISA</paymentType><percentage>2.50</percentage>'
         . '</surcharge></surcharges>';

--- a/tests/Message/ServerNotifyRequestTest.php
+++ b/tests/Message/ServerNotifyRequestTest.php
@@ -62,8 +62,8 @@ class ServerNotifyRequestTest extends TestCase
 
         $this->request->setSecurityKey('JEUPDN1N7E');
 
-        // With the security key added, the signatue check will now be valid,
-        // i.e. an untampered inbound notification.
+        // With the security key added, the signature check will now be valid,
+        // i.e. an un-tampered inbound notification.
 
         $this->assertTrue($this->request->isValid());
 
@@ -123,7 +123,7 @@ class ServerNotifyRequestTest extends TestCase
             $this->getHttpRequest()
         );
 
-        // The transactino reference in Response and ServerNotifyTrait
+        // The transaction reference in Response and ServerNotifyTrait
         // will return null if there is no transaction data provided
         // by the gateway.
 
@@ -227,7 +227,7 @@ class ServerNotifyRequestTest extends TestCase
     }
 
     /**
-     * sendRequest lets you return a raw message with no additinal
+     * sendRequest lets you return a raw message with no additional
      * checks on the validity of what was received.
      */
     public function testSendResponse()

--- a/tests/Message/SharedCaptureRequestTest.php
+++ b/tests/Message/SharedCaptureRequestTest.php
@@ -25,13 +25,13 @@ class SharedCaptureRequestTest extends TestCase
 
         $this->assertSame('RELEASE', $this->request->getTxType());
 
-        // User authenticate explicity true.
+        // User authenticate explicitly true.
 
         $this->request->setUseAuthenticate(true);
 
         $this->assertSame('AUTHORISE', $this->request->getTxType());
 
-        // User authenticate explicity false (back to the default).
+        // User authenticate explicitly false (back to the default).
 
         $this->request->setUseAuthenticate(false);
 


### PR DESCRIPTION
This is a pull request that adds the PayPal integration that was built as part of the oilstone/omnipay-sagepay fork, however that fork cannot be merged back in due to changes in the composer package definitions.

This is still a work in progress and will still need to be tested but it is a start to adding proper PayPal integration into this package.