### PR TITLE
Do not treat an empty card as a provided card

### DIFF
--- a/src/Message/SharedRepeatAuthorizeRequest.php
+++ b/src/Message/SharedRepeatAuthorizeRequest.php
@@ -69,8 +69,7 @@ class SharedRepeatAuthorizeRequest extends AbstractRequest
         $card = $this->getCard();
 
         // If a card is provided, then assume all billing details are being updated.
-
-        if ($card) {
+        if ($card && !empty($card->getParameters()) && !empty(array_filter($card->getParameters()))) {
             $data = $this->getBillingAddressData($data);
 
             // If the customer is present, then the CV2 can be supplied again for extra security.


### PR DESCRIPTION
Wiping out the whole array is pretty extreme. Only do it if the card array actually has
meaningful values. The code that calls this might be trying to support multiple
processors so don't assume it 'knows' not to pass an empty card if the processor is sagepay

https://github.com/thephpleague/omnipay-sagepay/issues/157#issuecomment-757448484