### PR TITLE
Fix protocol 4.00 VPSSignature check

### DIFF
--- a/src/Message/ServerCompleteAuthorizeRequest.php
+++ b/src/Message/ServerCompleteAuthorizeRequest.php
@@ -53,7 +53,12 @@ class ServerCompleteAuthorizeRequest extends AbstractRequest
             $this->httpRequest->request->get('DeclineCode', '').
             $this->httpRequest->request->get('ExpiryDate', '').
             $this->httpRequest->request->get('FraudResponse', '').
-            $this->httpRequest->request->get('BankAuthCode', '');
+            $this->httpRequest->request->get('BankAuthCode', '').
+            // New for protocol v4.00
+            // Described in the docs here: https://developer.elavon.com/products/opayo-server/v1/notification-of-transaction-result
+            $this->httpRequest->request->get('ACSTransID', '').
+            $this->httpRequest->request->get('DSTransID', '').
+            $this->httpRequest->request->get('SchemeTraceID', '');
 
         return md5($signature_string);
     }

--- a/tests/ServerGatewayTest.php
+++ b/tests/ServerGatewayTest.php
@@ -120,9 +120,14 @@ class ServerGatewayTest extends GatewayTestCase
                 'DeclineCode' => '00',
                 'ExpiryDate' => '0722',
                 'BankAuthCode' => '999777',
+                // New fields for protocol v4.0
+                'ACSTransID' => 'abcuuid',
+                'DSTransID' => '123uuid',
+                'SchemeTraceID' => 'V123',
                 'VPSSignature' => md5(
                     '{F955C22E-F67B-4DA3-8EA3-6DAC68FA59D2}'
                     . '438791' . 'OK' . 'bexamplecJEUPDN1N7Edefghijklm' . '00' . '0722' . '999777'
+                    . 'abcuuid' . '123uuid' . 'V123'
                 ),
             )
         );


### PR DESCRIPTION
Hi,

A bit of an urgent request as Elavon/Opayo are forcing their URL updates in a few days on the 31st of March.

Upgrading this omnipay sagepay package from version 3 to version 4 has resulted in errors on both sandbox and production environments. Which results is unable to take payments at all.

Only version 4 of this package has the new URLs which will break version 3 of this package once Opayo disables the old SagePay URLs.
Expect a lot of people on version 3 with broken installs!

I've found and fixed the protocol 4.00 errors in this merge request.

The issue I was having was, after creating a new transaction and being redirected to Opayo hosted forms, completing the payment Opayo will send data back to us. The data is verified in the package via the VPSSignature. However the current package does not check for the new protocol version 4.00 fields and is always returning an InvalidResponseException.
 
The cause is Opayo protocol version 4.00 has added new fields to check in the VPSSignature when using the Server Gateway.
(I'm unsure if other integrations such as their Form Integration is affected).

The Opayo documentation is here:
https://developer.elavon.com/products/opayo-server/v1/notification-of-transaction-result
Their docs might error, they require you to https://developer.elavon.com select your country and then click the link.

Please can you check this urgently and merge in before 31st of March otherwise many integrations will break.